### PR TITLE
No dtype arg for Qwen3 models

### DIFF
--- a/src/heretic/model.py
+++ b/src/heretic/model.py
@@ -55,7 +55,7 @@ class Model:
             try:
                 self.model = AutoModelForCausalLM.from_pretrained(
                     settings.model,
-                    dtype=dtype,
+                    # dtype=dtype,
                     device_map=settings.device_map,
                 )
 
@@ -91,7 +91,7 @@ class Model:
 
         self.model = AutoModelForCausalLM.from_pretrained(
             self.settings.model,
-            dtype=dtype,
+            # dtype=dtype,
             device_map=self.settings.device_map,
         )
 


### PR DESCRIPTION
@p-e-w Hey bro!

Fantastic work!

Sending you this tiny PR because I was not able to run it without commenting dtype args for Qwen3 models.
I think you need to refactor loading or remove this arg completely.

Sincerely,

Alex