### PR TITLE
perf: empty cache after using residuals and between trials

### DIFF
--- a/src/heretic/main.py
+++ b/src/heretic/main.py
@@ -39,6 +39,7 @@ from .utils import (
     get_trial_parameters,
     load_prompts,
     print,
+    empty_cache,
 )
 
 
@@ -193,6 +194,9 @@ def run():
         p=2,
         dim=1,
     )
+    # we don't need the residuals after computing refusal directions
+    del good_residuals, bad_residuals
+    empty_cache()
 
     trial_index = 0
     start_time = time.perf_counter()


### PR DESCRIPTION
Great work btw, this is an awesome project and looking forward to seeing it grow, I'm still learning and this has been a fun repo to hack around in :) 

I'm pretty sure we can free the residuals as soon as the refusal directions have been computed, and we can also clear the cache between trials.

Tested on my laptop 4060 while abliterating Qwen3-0.6B and peak GPU usage saw a slight decline