### PR TITLE
Fix KeyError when HuggingFace user profile fields are missing

### DIFF
--- a/src/heretic/main.py
+++ b/src/heretic/main.py
@@ -415,8 +415,10 @@ def run():
                             continue
 
                         user = huggingface_hub.whoami(token)
+                        fullname = user.get('fullname', user.get('name', 'Unknown'))
+                        email = user.get('email', 'Not provided')
                         print(
-                            f"Logged in as [bold]{user['fullname']} ({user['email']})[/]"
+                            f"Logged in as [bold]{fullname} ({email})[/]"
                         )
 
                         repo_id = questionary.text(


### PR DESCRIPTION
This PR fixes a bug where users without a public email or fullname set in their HuggingFace profile would encounter a KeyError during the model upload process.

## Changes
- Updated the HuggingFace login display to use .get() method with fallback values for optional profile fields (fullname and email)
- Added graceful handling to prevent crashes when these fields are not available in the user profile

## Testing
Tested with a HuggingFace account that has incomplete profile information.

## Related
This resolves the issue where uploading models to HuggingFace would fail with a KeyError on the email or fullname field.
