### PR TITLE
Fix support for MXFP4 quantized models with Triton tensors

### DIFF
--- a/src/heretic/model.py
+++ b/src/heretic/model.py
@@ -109,6 +109,11 @@ class Model:
         matrices = {}
 
         def try_add(component: str, matrix: Any):
+            # Handle Triton tensors (e.g., from MXFP4 quantization) by extracting
+            # the underlying PyTorch tensor via the .data attribute.
+            if hasattr(matrix, "data") and torch.is_tensor(matrix.data):
+                matrix = matrix.data
+
             assert torch.is_tensor(matrix)
 
             if component not in matrices:


### PR DESCRIPTION
## Problem

When loading models with MXFP4 quantization (e.g., `openai/gpt-oss-20b`), heretic fails with:

```
KeyError: 'mlp.down_proj'
```

This occurs because the `transformers` library uses Triton tensors for MXFP4 quantized weights, and `torch.is_tensor()` returns `False` for them, causing the assertion in `try_add()` to fail.

## Solution

Extract the underlying PyTorch tensor via the `.data` attribute when encountering Triton tensors. The `.data` attribute contains a regular PyTorch tensor that supports all required operations (`.device`, `.sub_()`, matrix multiplication).

## Testing
- Tested with `openai/gpt-oss-20b`
- Model loads successfully and recognizes both `attn.o_proj` and `mlp.down_proj` components
- Maintains compatibility with non-quantized models

## Environment
- PyTorch 2.9.1+cu130
- transformers 4.57.1
- triton 3.5.1
- kernels 0.11.0

Fixes loading MXFP4 quantized models while maintaining backward compatibility.