### PR TITLE
Use `PYTORCH_ALLOC_CONF` instead of deprecated `PYTORCH_CUDA_ALLOC_CONF`

### DIFF
--- a/src/heretic/main.py
+++ b/src/heretic/main.py
@@ -46,7 +46,10 @@ from .utils import (
 
 def run():
     # Enable expandable segments to reduce memory fragmentation on multi-GPU setups.
-    if "PYTORCH_ALLOC_CONF" not in os.environ and "PYTORCH_CUDA_ALLOC_CONF" not in os.environ:
+    if (
+        "PYTORCH_ALLOC_CONF" not in os.environ
+        and "PYTORCH_CUDA_ALLOC_CONF" not in os.environ
+    ):
         os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
 
     # Modified "Pagga" font from https://budavariam.github.io/asciiart-text/


### PR DESCRIPTION
## Problem
With #17 I introduced setting `PYTORCH_CUDA_ALLOC_CONF` to `expandable_segments:True` to reduce memory fragmentation for the model. Even though PyTorch docs sometimes still mention `PYTORCH_CUDA_ALLOC_CONF`, during runtime we get a deprecation warning.

```
[W1120 14:44:07.101109672 AllocatorConfig.cpp:28] Warning: PYTORCH_CUDA_ALLOC_CONF is deprecated, use PYTORCH_ALLOC_CONF instead
```

## Solution
Use `PYTORCH_ALLOC_CONF` instead of `PYTORCH_CUDA_ALLOC_CONF`.

## Result
Suppression of the deprecation warning.