### PR TITLE
add support for hybrid layer models: conv, mamba

### DIFF
--- a/src/heretic/config.py
+++ b/src/heretic/config.py
@@ -153,6 +153,11 @@ class Settings(BaseSettings):
         description="Dataset of prompts that tend to result in refusals (used for evaluating model performance).",
     )
 
+    show_all_trials: bool = Field(
+        default=False,
+        description="If set, show all evaluated trials in the selection menu, including those with high KL divergence.",
+    )
+
     # "Model" refers to the Pydantic model of the settings class here,
     # not to the language model. The field must have this exact name.
     model_config = SettingsConfigDict(

--- a/src/heretic/main.py
+++ b/src/heretic/main.py
@@ -500,6 +500,7 @@ def run():
                             continue
 
                         print("Saving model...")
+                        model.sanitize_generation_config()
                         model.model.save_pretrained(save_directory)
                         model.tokenizer.save_pretrained(save_directory)
                         print(f"Model saved to [bold]{save_directory}[/].")
@@ -541,6 +542,7 @@ def run():
 
                         print("Uploading model...")
 
+                        model.sanitize_generation_config()
                         model.model.push_to_hub(
                             repo_id,
                             private=private,

--- a/src/heretic/main.py
+++ b/src/heretic/main.py
@@ -439,7 +439,7 @@ def run():
     print()
     if excluded_trials > 0:
         print(
-            f"[grey50]Filtered out {excluded_trials} trials with KL divergence > {kl_threshold:.1f}. "
+            f"[grey50]Filtered out {excluded_trials} Pareto trials with KL divergence > {kl_threshold:.1f}. "
             f"Set --show-all-trials to include them.[/]"
         )
     print(

--- a/src/heretic/main.py
+++ b/src/heretic/main.py
@@ -291,10 +291,23 @@ def run():
             # The parameter ranges are based on experiments with various models
             # and much wider ranges. They are not set in stone and might have to be
             # adjusted for future models.
+            if "conv" in component or "mamba" in component:
+                max_weight_range = (0.8, 2.5)
+                min_weight_fraction_range = (0.0, 0.8)
+            elif "attn" in component:
+                max_weight_range = (0.8, 1.8)
+                min_weight_fraction_range = (0.0, 1.0)
+            elif "shared" in component:
+                max_weight_range = (0.8, 2.0)
+                min_weight_fraction_range = (0.0, 0.9)
+            else:
+                max_weight_range = (0.8, 2.5)
+                min_weight_fraction_range = (0.0, 0.9)
+
             max_weight = trial.suggest_float(
                 f"{component}.max_weight",
-                0.8,
-                1.5,
+                max_weight_range[0],
+                max_weight_range[1],
             )
             max_weight_position = trial.suggest_float(
                 f"{component}.max_weight_position",
@@ -306,8 +319,8 @@ def run():
             # The value is transformed into the actual min_weight value below.
             min_weight = trial.suggest_float(
                 f"{component}.min_weight",
-                0.0,
-                1.0,
+                min_weight_fraction_range[0],
+                min_weight_fraction_range[1],
             )
             min_weight_distance = trial.suggest_float(
                 f"{component}.min_weight_distance",

--- a/src/heretic/model.py
+++ b/src/heretic/model.py
@@ -175,6 +175,8 @@ class Model:
 
         with suppress(Exception):
             try_add("attn.o_proj", layer.self_attn.o_proj.weight)
+        with suppress(Exception):
+            try_add("attn.o_proj", layer.self_attn.out_proj.weight)
 
         # Most dense models.
         with suppress(Exception):
@@ -205,6 +207,27 @@ class Model:
         with suppress(Exception):
             for expert in layer.moe.experts:
                 try_add("mlp.down_proj", expert.output_linear.weight)
+
+        # LFM/LFM-MoE feed-forward modules.
+        with suppress(Exception):
+            try_add("mlp.down_proj", layer.feed_forward.w2.weight)
+        with suppress(Exception):
+            try_add("mlp.down_proj", layer.feed_forward.output_linear.weight)
+        with suppress(Exception):
+            # Some MoE blocks expose experts as an attribute.
+            try_add("mlp.down_proj", layer.feed_forward.experts.down_proj)
+        with suppress(Exception):
+            try_add("mlp.down_proj", layer.feed_forward.experts.w2)
+        with suppress(Exception):
+            for expert in layer.feed_forward.experts:
+                try_add("mlp.down_proj", expert.down_proj.weight)
+        with suppress(Exception):
+            for expert in layer.feed_forward.experts:
+                try_add("mlp.down_proj", expert.w2.weight)
+
+        # LFM-style conv layers.
+        with suppress(Exception):
+            try_add("conv.out_proj", layer.conv.out_proj.weight)
 
         # Mamba/SSM layers.
         with suppress(Exception):


### PR DESCRIPTION
this PR adds support for new layer types: mamba, convolution layers as well as for hybrid layers (vary throughout model). This enables use for models like granite-4.0 , LFM2 etc.

- Add LFM/LFM-MoE support: extract conv/MLP/expert projections, handle self_attn.out_proj, and enable trust_remote_code for LFM loaders.
- Broaden component detection to cover Granite hybrid/shared MLP, Mixtral/JetMoE tensors, and mamba/conv layers; keep abliteration resilient when layers lack matrices.
- Tune Optuna search ranges for hybrid/conv stacks and add optional filtering of high-KL (>2) trials in the selection menu (show_all_trials to disable).
- Improve trial menu usability: sort by refusals (then KL), surface how many trials were filtered, and maintain original ordering otherwise.
- fix: add basic generation-config sanitization so saves/uploads won’t fail (_if the generation config is inconsistent/has issues, huggingface will now raise errors instead of saving/uploading... problematic in the CLI menu at the end_)