### PR TITLE
perf: optimize abliteration matrix op

### DIFF
--- a/src/heretic/model.py
+++ b/src/heretic/model.py
@@ -228,8 +228,9 @@ class Model:
                 # Projects any right-multiplied vector(s) onto the subspace
                 # spanned by the refusal direction.
                 # We use the property (r r^T) W = r (r^T W) to avoid computing
-                # the O(d^2 k) projector matrix and the O(d^3) matrix multiplication.
-                # W_new = W - r * (r^T W)
+                # the O(d^2) projector matrix and the O(d^2 k) matrix multiplication.
+                # (α is the weight)
+                # W_new = W - α(r (r^T W))
                 r = layer_refusal_direction.to(self.model.dtype)
 
                 for matrix in matrices:
@@ -237,7 +238,7 @@ class Model:
                     r_device = r.to(matrix.device)
 
                     # Calculate the projection scalars: (r^T W)
-                    # r is (1, d), matrix is (d, k) -> result is (k,)
+                    # r is (d,), matrix is (d, k) -> result is (k,)
                     r_transpose_W = torch.matmul(r_device, matrix)
 
                     # Compute the rank-1 update r (r^T W) using the outer product form
@@ -362,7 +363,7 @@ class Model:
 
         return torch.cat(logprobs, dim=0)
 
-    def stream_cresponse(self, chat: list[dict[str, str]]) -> str:
+    def stream_chat_response(self, chat: list[dict[str, str]]) -> str:
         chat_prompt: str = self.tokenizer.apply_chat_template(
             chat,
             add_generation_prompt=True,


### PR DESCRIPTION
Found a possible small VRAM optimization when hacking around. We want to compute `M - weight * v (v^T M)` where `v` is the refusal direction for a layer. Instead of building the projector matrix in `O(d^2)` memory and `projector @ matrix` which is `O(d^2*k)`, we can use the identity `(v v^T) M = v(v^T M)` to apply the transformation directly to the weights. I made the varnames and comments correspond to the original Arditi et. al paper just for clarity

Was able to save about 2MB VRAM on my very low-power 4060 with Qwen-0.6B and it should increase for larger models. If my math is correct, the projector matrix size would be around 256MB for a 70B model which is a decent chunk saved, especially with the cost of VRAM these days! There was a very slight increase in computation time, possibly from CPU overhead from Python (I have no idea tbh) but it should be negligible. 

## Before optimization
```
GPU type: NVIDIA GeForce RTX 4060 Laptop GPU

Loading model Qwen/Qwen3-0.6B...
* Trying dtype auto... Ok
* Transformer model with 28 layers
* Abliterable components:
  * attn.o_proj: 1 matrices per layer
  * mlp.down_proj: 1 matrices per layer

* Transformer model with 28 layers
* Abliterable components:
  * attn.o_proj: 1 matrices per layer
  * mlp.down_proj: 1 matrices per layer

Loading good prompts from mlabonne/harmless_alpaca...
* 400 prompts loaded

Loading bad prompts from mlabonne/harmful_behaviors...
* 400 prompts loaded

Loading good evaluation prompts from mlabonne/harmless_alpaca...
* 100 prompts loaded
* Obtaining first-token probability distributions...

Loading bad evaluation prompts from mlabonne/harmful_behaviors...
* 100 prompts loaded
* Counting model refusals...
* Initial refusals: 38/100

Calculating per-layer refusal directions...
* Obtaining residuals for good prompts...
* Obtaining residuals for bad prompts...

Running trial 1 of 200...
* Parameters:
  * direction_index = 14.25
  * attn.o_proj.max_weight = 1.40
  * attn.o_proj.max_weight_position = 21.88
  * attn.o_proj.min_weight = 1.15
  * attn.o_proj.min_weight_distance = 5.46
  * mlp.down_proj.max_weight = 1.21
  * mlp.down_proj.max_weight_position = 20.43
  * mlp.down_proj.min_weight = 0.72Was able to save about 2MB VRAM on my very low-power 4060 with Qwen-0.6B and it should increase for larger models. If my math is correct, the projector matrix size would be around 256MB for a 70B model which is a decent chunk saved, especially with the cost of VRAM these days! There was a very slight increase in computation time, possibly from CPU overhead from Python (I have no idea tbh) but it should be negligible. 

  * mlp.down_proj.min_weight_distance = 15.00
* Reloading model...
* Abliterating...
  Abliteration logic took 0.0188s
  Peak VRAM overhead: 14.00 MiB
* Evaluating...
  * Obtaining first-token probability distributions...
  * KL divergence: 0.02
  * Counting model refusals...
  * Refusals: 17/100

Elapsed time: 8s
Estimated remaining time: 25m 13s

Running trial 2 of 200...
* Parameters:
  * direction_index = per layer
  * attn.o_proj.max_weight = 1.24
  * attn.o_proj.max_weight_position = 22.26
  * attn.o_proj.min_weight = 0.94
  * attn.o_proj.min_weight_distance = 1.12
  * mlp.down_proj.max_weight = 1.37
  * mlp.down_proj.max_weight_position = 26.44
  * mlp.down_proj.min_weight = 1.04
  * mlp.down_proj.min_weight_distance = 3.13
* Reloading model...
* Abliterating...
  Abliteration logic took 0.0017s
  Peak VRAM overhead: 14.00 MiB
* Evaluating...
  * Obtaining first-token probability distributions...
  * KL divergence: 0.06
  * Counting model refusals...
  * Refusals: 33/100

Elapsed time: 15s
Estimated remaining time: 25m 14s

Running trial 3 of 200...
* Parameters:
  * direction_index = per layer
  * attn.o_proj.max_weight = 0.90
  * attn.o_proj.max_weight_position = 21.58
  * attn.o_proj.min_weight = 0.53
  * attn.o_proj.min_weight_distance = 4.89
  * mlp.down_proj.max_weight = 1.47
  * mlp.down_proj.max_weight_position = 18.15
  * mlp.down_proj.min_weight = 0.19
  * mlp.down_proj.min_weight_distance = 13.89
* Reloading model...
* Abliterating...
  Abliteration logic took 0.0043s
  Peak VRAM overhead: 14.00 MiB
* Evaluating...
  * Obtaining first-token probability distributions...
  * KL divergence: 0.14
  * Counting model refusals...
```
## After optimization
```
GPU type: NVIDIA GeForce RTX 4060 Laptop GPU

Loading model Qwen/Qwen3-0.6B...
* Trying dtype auto... Ok
* Transformer model with 28 layers
* Abliterable components:
  * attn.o_proj: 1 matrices per layer
  * mlp.down_proj: 1 matrices per layer

Loading good prompts from mlabonne/harmless_alpaca...
* 400 prompts loaded

Loading bad prompts from mlabonne/harmful_behaviors...
* 400 prompts loaded

Loading good evaluation prompts from mlabonne/harmless_alpaca...
* 100 prompts loaded
* Obtaining first-token probability distributions...

Loading bad evaluation prompts from mlabonne/harmful_behaviors...
* 100 prompts loaded
* Counting model refusals...
* Initial refusals: 38/100

Calculating per-layer refusal directions...
* Obtaining residuals for good prompts...
* Obtaining residuals for bad prompts...

Running trial 1 of 200...
* Parameters:
  * direction_index = per layer
  * attn.o_proj.max_weight = 1.17
  * attn.o_proj.max_weight_position = 17.45
  * attn.o_proj.min_weight = 0.17
  * attn.o_proj.min_weight_distance = 1.93
  * mlp.down_proj.max_weight = 1.29
  * mlp.down_proj.max_weight_position = 24.54
  * mlp.down_proj.min_weight = 0.58
  * mlp.down_proj.min_weight_distance = 5.00
* Reloading model...
* Abliterating...
  Abliteration logic took 0.0087s
  Peak VRAM overhead: 12.01 MiB
* Evaluating...
  * Obtaining first-token probability distributions...
  * KL divergence: 0.08
  * Counting model refusals...
  * Refusals: 30/100

Elapsed time: 8s
Estimated remaining time: 26m 32s

Running trial 2 of 200...
* Parameters:
  * direction_index = 19.83
  * attn.o_proj.max_weight = 1.49
  * attn.o_proj.max_weight_position = 23.52
  * attn.o_proj.min_weight = 0.85
  * attn.o_proj.min_weight_distance = 12.74
  * mlp.down_proj.max_weight = 0.81
  * mlp.down_proj.max_weight_position = 25.95
  * mlp.down_proj.min_weight = 0.52
  * mlp.down_proj.min_weight_distance = 8.02
* Reloading model...
* Abliterating...
  Abliteration logic took 0.0041s
  Peak VRAM overhead: 12.01 MiB
* Evaluating...
  * Obtaining first-token probability distributions...
  * KL divergence: 0.05
  * Counting model refusals...
  * Refusals: 29/100

Elapsed time: 16s
Estimated remaining time: 25m 56s

Running trial 3 of 200...
* Parameters:
  * direction_index = per layer
  * attn.o_proj.max_weight = 1.05
  * attn.o_proj.max_weight_position = 20.51
  * attn.o_proj.min_weight = 0.85
  * attn.o_proj.min_weight_distance = 15.69
  * mlp.down_proj.max_weight = 1.05
  * mlp.down_proj.max_weight_position = 23.62
  * mlp.down_proj.min_weight = 0.49
  * mlp.down_proj.min_weight_distance = 12.59
* Reloading model...
* Abliterating...
  Abliteration logic took 0.0087s
  Peak VRAM overhead: 12.01 MiB
* Evaluating...
  * Obtaining first-token probability distributions...
  * KL divergence: 0.11
  * Counting model refusals...
```