### PR TITLE
Add enable_thinking config option for Qwen3 and similar models

### DIFF
--- a/src/heretic/config.py
+++ b/src/heretic/config.py
@@ -53,6 +53,15 @@ class Settings(BaseSettings):
         description="Whether to trust remote code when loading the model.",
     )
 
+    enable_thinking: bool | None = Field(
+        default=None,
+        description=(
+            "Whether to enable thinking mode for models that support it (e.g., Qwen3). "
+            "Set to False to disable thinking tokens during abliteration. "
+            "If None, uses the model's default behavior."
+        ),
+    )
+
     batch_size: int = Field(
         default=0,  # auto
         description="Number of input sequences to process in parallel (0 = auto).",

--- a/src/heretic/model.py
+++ b/src/heretic/model.py
@@ -251,10 +251,19 @@ class Model:
     ) -> tuple[BatchEncoding, GenerateOutput | LongTensor]:
         chats = [self.get_chat(prompt) for prompt in prompts]
 
+        # Build kwargs for apply_chat_template
+        template_kwargs: dict[str, Any] = {
+            "add_generation_prompt": True,
+            "tokenize": False,
+        }
+
+        # Add enable_thinking if configured (for Qwen3 and similar models)
+        if self.settings.enable_thinking is not None:
+            template_kwargs["enable_thinking"] = self.settings.enable_thinking
+
         chat_prompts: list[str] = self.tokenizer.apply_chat_template(
             chats,
-            add_generation_prompt=True,
-            tokenize=False,
+            **template_kwargs,
         )
 
         inputs = self.tokenizer(
@@ -353,10 +362,19 @@ class Model:
         return torch.cat(logprobs, dim=0)
 
     def stream_chat_response(self, chat: list[dict[str, str]]) -> str:
+        # Build kwargs for apply_chat_template
+        template_kwargs: dict[str, Any] = {
+            "add_generation_prompt": True,
+            "tokenize": False,
+        }
+
+        # Add enable_thinking if configured (for Qwen3 and similar models)
+        if self.settings.enable_thinking is not None:
+            template_kwargs["enable_thinking"] = self.settings.enable_thinking
+
         chat_prompt: str = self.tokenizer.apply_chat_template(
             chat,
-            add_generation_prompt=True,
-            tokenize=False,
+            **template_kwargs,
         )
 
         inputs = self.tokenizer(


### PR DESCRIPTION
## Summary

Some models like Qwen3 support a "thinking mode" where the model generates internal reasoning tokens (`<think>...</think>`) before the actual response. This behavior is controlled by the `enable_thinking` parameter in `apply_chat_template()`.

### The Problem

When abliterating these models, the thinking mode setting during training **must match** the intended inference setting. If the model is abliterated with thinking mode ON but used with thinking mode OFF (or vice versa), the abliteration may not transfer properly because the model's behavior differs significantly between modes.

We discovered this when abliterating Qwen3-8B - the abliteration appeared to work (refusals dropped from 43 to 37 during training), but when testing with `enable_thinking=False`, the model still refused most prompts. The abliteration only worked in thinking mode because that's how it was trained.

### The Solution

This PR adds an `enable_thinking` configuration option that:
- When set to `False`: Disables thinking mode during abliteration
- When set to `True`: Enables thinking mode during abliteration  
- When set to `None` (default): Uses the model's default behavior (backwards compatible)

The setting is applied to both `generate()` and `stream_chat_response()` methods.

### Usage

```bash
# Via CLI
heretic --model Qwen/Qwen3-8B --enable-thinking false

# Via config.toml
enable_thinking = false

# Via environment variable
HERETIC_ENABLE_THINKING=false
```

### Changes

- `config.py`: Added `enable_thinking: bool | None` field with default `None`
- `model.py`: Updated `generate()` and `stream_chat_response()` to pass `enable_thinking` to `apply_chat_template()` when configured

### Testing

Tested with Qwen3-4B and Qwen3-8B models. With `enable_thinking=false`, the abliterated models now properly respond without refusals when used in non-thinking mode.

## Test plan

- [ ] Test with a Qwen3 model using `--enable-thinking false`
- [ ] Verify abliteration works in non-thinking mode
- [ ] Verify default behavior (None) is unchanged for other models
