### PR TITLE
feat: add support for plain text files as prompt datasets

### DIFF
--- a/config.default.toml
+++ b/config.default.toml
@@ -109,15 +109,14 @@ system_prompt = "You are a helpful assistant."
 # The dataset can be:
 #   - A Hugging Face dataset ID (e.g., "mlabonne/harmless_alpaca")
 #   - A local directory containing a dataset
-#   - A plain text file (.txt) with one prompt per line
+#   - A plain text file with one prompt per line
 #
-# Text file format:
+# For text files:
 #   - One prompt per line (UTF-8 encoding)
 #   - Empty lines and whitespace-only lines are ignored
 #   - Leading/trailing whitespace is stripped from each prompt
-#   - The "column" field is ignored for text files
-#   - Slice notation works: split = "[:100]" uses first 100 lines,
-#     split = "[50:150]" uses lines 50-149
+#   - The "split" and "column" fields are optional (ignored for text files)
+#   - Slice notation works in "split": split = "[:100]" uses first 100 lines
 [good_prompts]
 dataset = "mlabonne/harmless_alpaca"
 split = "train[:400]"

--- a/config.default.toml
+++ b/config.default.toml
@@ -106,6 +106,11 @@ refusal_markers = [
 system_prompt = "You are a helpful assistant."
 
 # Dataset of prompts that tend to not result in refusals (used for calculating refusal directions).
+# The dataset can be:
+#   - A Hugging Face dataset ID (e.g., "mlabonne/harmless_alpaca")
+#   - A local directory containing a dataset
+#   - A plain text file (.txt) with one prompt per line
+# For text files, the split notation can still be used (e.g., split = "[:100]" for first 100 lines).
 [good_prompts]
 dataset = "mlabonne/harmless_alpaca"
 split = "train[:400]"

--- a/config.default.toml
+++ b/config.default.toml
@@ -110,7 +110,14 @@ system_prompt = "You are a helpful assistant."
 #   - A Hugging Face dataset ID (e.g., "mlabonne/harmless_alpaca")
 #   - A local directory containing a dataset
 #   - A plain text file (.txt) with one prompt per line
-# For text files, the split notation can still be used (e.g., split = "[:100]" for first 100 lines).
+#
+# Text file format:
+#   - One prompt per line (UTF-8 encoding)
+#   - Empty lines and whitespace-only lines are ignored
+#   - Leading/trailing whitespace is stripped from each prompt
+#   - The "column" field is ignored for text files
+#   - Slice notation works: split = "[:100]" uses first 100 lines,
+#     split = "[50:150]" uses lines 50-149
 [good_prompts]
 dataset = "mlabonne/harmless_alpaca"
 split = "train[:400]"

--- a/src/heretic/config.py
+++ b/src/heretic/config.py
@@ -23,9 +23,15 @@ class DatasetSpecification(BaseModel):
         description="Hugging Face dataset ID, or path to dataset on disk."
     )
 
-    split: str = Field(description="Portion of the dataset to use.")
+    split: str | None = Field(
+        default=None,
+        description="Portion of the dataset to use. Required for HuggingFace datasets, optional for text files.",
+    )
 
-    column: str = Field(description="Column in the dataset that contains the prompts.")
+    column: str | None = Field(
+        default=None,
+        description="Column in the dataset that contains the prompts. Required for HuggingFace datasets, ignored for text files.",
+    )
 
     prefix: str = Field(
         default="",


### PR DESCRIPTION
## Summary
- Adds support for loading prompts from plain text files (one prompt per line)
- Provides a simpler alternative to creating HuggingFace datasets for custom prompts
- Slice notation works (e.g., `split = "[:100]"` for first 100 lines)

## Changes
- Modified `load_prompts()` in `utils.py` to detect and parse plain text files
- Added `_get_split_slice()` helper function for robust split parsing (reuses `ReadInstruction`)
- Made `split` and `column` fields optional in `DatasetSpecification` (ignored for text files)
- Added documentation in `config.default.toml` explaining the dataset options

## Example usage
```toml
[bad_prompts]
dataset = "/path/to/my_prompts"
split = "[:100]"  # Optional: use first 100 lines
```

## Test plan
- [x] Tested loading full text file
- [x] Tested slice notation (`[:3]`, `[1:3]`, `[:2]`)
- [x] Verified prefix/suffix options work correctly
- [x] Verified existing HF dataset loading still works (fallback path)
- [x] Verified proper error messages when split/column missing for HF datasets

Closes #98