### PR TITLE
fix: Allow abliterating VL models

### DIFF
--- a/src/heretic/main.py
+++ b/src/heretic/main.py
@@ -31,12 +31,11 @@ from optuna.trial import TrialState
 from pydantic import ValidationError
 from questionary import Choice
 from rich.traceback import install
-from transformers import AutoModelForCausalLM
 
 from .analyzer import Analyzer
 from .config import QuantizationMethod, Settings
 from .evaluator import Evaluator
-from .model import AbliterationParameters, Model
+from .model import AbliterationParameters, Model, get_model_class
 from .utils import (
     empty_cache,
     format_duration,
@@ -80,7 +79,7 @@ def obtain_merge_strategy(settings: Settings) -> str | None:
             # These are expected and harmless since we're only inspecting model structure, not running inference.
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore")
-                meta_model = AutoModelForCausalLM.from_pretrained(
+                meta_model = get_model_class(settings.model).from_pretrained(
                     settings.model,
                     device_map="meta",
                     torch_dtype=torch.bfloat16,


### PR DESCRIPTION
Per https://huggingface.co/docs/transformers/en/model_doc/auto#auto-classes, it indicates that "There is one class of AutoModel for each task." Since we're not using AutoModel (allowing it to pick the task automatically), expose a flag to allow for a different "task", which allows (at least) Qwen3-VL to be abliterated.