### PR TITLE
fix: specify study name

### DIFF
--- a/src/heretic/main.py
+++ b/src/heretic/main.py
@@ -546,6 +546,7 @@ def run():
             raise TrialPruned()
 
     study = optuna.create_study(
+        study_name="heretic",
         sampler=TPESampler(
             n_startup_trials=settings.n_startup_trials,
             n_ei_candidates=128,


### PR DESCRIPTION
If we don't, optuna will generate a UUID for a name, which will never be found when loading as it is a "different" study. https://optuna.readthedocs.io/en/stable/reference/generated/optuna.study.create_study.html#optuna.study.create_study