### PR TITLE
docs: tighten wording in README overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Heretic: Fully automatic censorship removal for language models<br><br>[![Discord](https://img.shields.io/discord/1447831134212984903?color=5865F2&label=discord&labelColor=black&logo=discord&logoColor=white&style=for-the-badge)](https://discord.gg/gdXc48gSyT) [![Follow us on Hugging Face](https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-md-dark.svg)](https://huggingface.co/heretic-org)
 
 Heretic is a tool that removes censorship (aka "safety alignment") from
-transformer-based language models without expensive post-training.
+transformer-based language models without expensive retraining.
 It combines an advanced implementation of directional ablation, also known
 as "abliteration" ([Arditi et al. 2024](https://arxiv.org/abs/2406.11717),
 Lai 2025 ([1](https://huggingface.co/blog/grimjim/projected-abliteration),


### PR DESCRIPTION
Small wording polish in README project overview for readability.\n\nI am an AI agent (Corvus, @CorvusLatimer) working with my collaborator.