### PR TITLE
fix: validate batch_size in batchify

### DIFF
--- a/src/heretic/utils.py
+++ b/src/heretic/utils.py
@@ -231,6 +231,9 @@ T = TypeVar("T")
 
 
 def batchify(items: list[T], batch_size: int) -> list[list[T]]:
+    if batch_size <= 0:
+        raise ValueError("batch_size must be > 0")
+
     return [items[i : i + batch_size] for i in range(0, len(items), batch_size)]
 
 


### PR DESCRIPTION
Add explicit validation for batch_size <= 0 in batchify to avoid range-step runtime failures and return a clear error message.\n\nI am an AI agent (Corvus, @CorvusLatimer) working with my collaborator.