### PR TITLE
feat: add Qwen3.5 MoE hybrid layer support

### DIFF
--- a/src/heretic/model.py
+++ b/src/heretic/model.py
@@ -167,13 +167,12 @@ class Model:
         # across layers (e.g. "o_proj" on attention layers, "out_proj" on linear attention layers).
         target_modules_set: set[str] = set()
         layers = self.get_layers()
-        for layer_index in range(len(layers)):
-            layer = layers[layer_index]
-            named = {id(m): name.split(".")[-1] for name, m in layer.named_modules()}
+        for layer_index, layer in enumerate(layers):
+            module_id_to_leaf_name = {id(m): name.split(".")[-1] for name, m in layer.named_modules()}
             for modules_list in self.get_layer_modules(layer_index).values():
                 for mod in modules_list:
-                    if id(mod) in named:
-                        target_modules_set.add(named[id(mod)])
+                    if id(mod) in module_id_to_leaf_name:
+                        target_modules_set.add(module_id_to_leaf_name[id(mod)])
         target_modules = list(target_modules_set)
 
         if self.settings.row_normalization != RowNormalization.FULL:


### PR DESCRIPTION
## Summary

Qwen3.5 MoE uses GatedDeltaNet (linear attention) on some layers instead of standard self-attention. This causes abliteration to fail because `self_attn.o_proj` doesn't exist on those layers.

- Wrap `self_attn.o_proj` access in `suppress(Exception)` and add `linear_attn.out_proj` as alternative attention out-projection for GatedDeltaNet layers
- Scan all layers in `get_abliterable_components()` instead of only layer 0, since hybrid models have different components on different layers
- Derive LoRA `target_modules` from actual `named_modules()` instead of splitting component keys, which fails when module names differ across layers (e.g. `o_proj` vs `out_proj`)

## Test results

Successfully abliterated **Qwen3.5-397B-A17B** (7× H200 SXM):
- **Trial 104** selected from 200-trial Pareto front
- **Refusals: 7/100**, KL divergence: **0.2676**
- Parameters: `direction_index=52.45, attn.o_proj.max_weight=1.34, max_weight_position=36.86, min_weight=0.66, min_weight_distance=15.21`

The resulting model passes both censorship removal and quality preservation tests.

## Relation to #43

This PR is complementary to #43 (hybrid layer support for LFM/Mamba/Conv). While #43 adds broad architecture support across `get_layer_matrices()`, this PR focuses specifically on Qwen3.5 MoE's GatedDeltaNet layers and fixes `get_layer_modules()` + LoRA targeting which #43 does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)