### PR TITLE
feat: Add GPT-OSS fused expert detection

### DIFF
--- a/src/heretic/model.py
+++ b/src/heretic/model.py
@@ -353,7 +353,7 @@ class Model:
             for expert in layer.mlp.experts:  # ty:ignore[possibly-missing-attribute, not-iterable]
                 try_add("mlp.down_proj", expert.down_proj)  # ty:ignore[possibly-missing-attribute]
 
-# GPT-OSS style fused experts (single 3D tensor for all experts).
+        # GPT-OSS style fused experts (single 3D tensor for all experts).
         with suppress(Exception):
             fused = layer.mlp.experts.down_proj
             if isinstance(fused, (Tensor, torch.nn.Parameter)) and fused.ndim == 3:


### PR DESCRIPTION
GPT-OSS models store MLP experts as a single 3D tensor `[num_experts, hidden, intermediate]` rather than individual `nn.Linear` modules. This patch adds detection for these fused experts so `mlp.down_proj` appears in abliterable components.

Results of this patch tested on:
- [openai/gpt-oss-120b (MXFP4)](https://huggingface.co/openai/gpt-oss-120b) - `mlp.down_proj` not detected due to custom MXFP4 tensor format
- [llmfan46/gpt-oss-120b-dequantized (BF16)](https://huggingface.co/llmfan46/gpt-oss-120b-dequantized) - `mlp.down_proj` detected and fully abliterable