### PR TITLE
feat: add Qwen3.5 MoE support with fused expert abliteration

### DIFF
--- a/src/heretic/model.py
+++ b/src/heretic/model.py
@@ -376,7 +376,7 @@ class Model:
         # but hybrid models (e.g. Qwen3.5 MoE) may use linear_attn on some layers.
         with suppress(Exception):
             try_add("attn.o_proj", layer.self_attn.o_proj)  # ty:ignore[possibly-missing-attribute]
-        # Qwen3.5 MoE GatedDeltaNet layers use linear_attn.out_proj
+        # Qwen3.5 MoE GatedDeltaNet layers use linear_attn.out_proj.
         with suppress(Exception):
             try_add("attn.out_proj", layer.linear_attn.out_proj)  # ty:ignore[possibly-missing-attribute]
 


### PR DESCRIPTION
## Summary

Adds full Qwen3.5 MoE support to Heretic, including **fused expert parameter abliteration** — the key feature missing from #187 and #193.

Qwen3.5 MoE differs from other supported MoE models in two ways that require special handling:

1. **Hybrid attention layers**: Some layers use standard `self_attn.o_proj`, others use GatedDeltaNet `linear_attn.out_proj`. Inspecting only layer 0 for component detection misses one or the other.

2. **Fused expert parameters**: Expert weights are stored as stacked `nn.Parameter` tensors (`[num_experts, out_features, in_features]`) instead of individual `nn.Module` instances per expert. LoRA cannot wrap raw parameters, so these experts were silently skipped during abliteration.

## Changes

- **Fused expert abliteration**: New `get_fused_expert_params()` detects stacked parameter tensors and applies direct weight modification with snapshot/restore for model reset
- **Hybrid layer support**: `linear_attn.out_proj` as alternative attention out-projection, `mlp.shared_expert.down_proj` for shared expert
- **Full-layer scanning**: `get_abliterable_components()` now scans all layers instead of only layer 0, since hybrid models have different components per layer
- **Robust LoRA targeting**: Derive `target_modules` from `named_modules()` instead of splitting component keys
- **Thinking mode handling**: Pass `enable_thinking=False` to `apply_chat_template()` so models with thinking mode (e.g. Qwen3.5) produce prompts without `<think>` tags. Falls back gracefully for tokenizers that don't support this kwarg.

## Comparison with other Qwen 3.5 MoE PRs

| Feature | This PR | #187 | #193 |
|---------|---------|------|------|
| Hybrid layer detection | ✅ | ✅ | ✅ |
| Shared expert | ✅ | ❌ | ✅ |
| Fused expert abliteration | ✅ | ❌ | ❌ |
| Separate attn component keys (o_proj + out_proj) | ✅ | ❌ | ✅ |
| `enable_thinking=False` | ✅ | ❌ | ❌ |

## Tested

Tested on **Qwen3.5-35B-A3B** (NVIDIA RTX PRO 6000 Blackwell):
- 200-trial Pareto optimization completes successfully
- Fused expert abliteration correctly modifies expert slices