### PR TITLE
fix(ara): store captured I/O on CPU for multi-GPU robustness

### DIFF
--- a/src/heretic/model.py
+++ b/src/heretic/model.py
@@ -803,8 +803,10 @@ class Model:
 
                 # inputs[0] and outputs have shape (prompt, position, component),
                 # so this extracts the input/output at the end of each prompt.
-                input = inputs[0][:, -1, :].detach().clone()
-                output = outputs[:, -1, :].detach().clone()
+                # Move to CPU to decouple from device assignments, which can
+                # change between model reloads in multi-GPU configurations.
+                input = inputs[0][:, -1, :].detach().clone().cpu()
+                output = outputs[:, -1, :].detach().clone().cpu()
 
                 # The modules associated with a component (e.g. expert MLPs)
                 # are not necessarily invoked in order, nor are all of them


### PR DESCRIPTION
## Summary

Extends d79a443 — that commit correctly moves I/O tensors to the weight matrix's device before L-BFGS optimization, but the captured tensors remain on their original GPU between trials. When `reset_model()` reloads the model, device assignments can change, leaving orphaned tensors on GPUs that now need that VRAM for the reloaded weights.

This adds `.cpu()` at capture time in `get_module_io`, so tensors are stored device-agnostic:

```python
input = inputs[0][:, -1, :].detach().clone().cpu()
output = outputs[:, -1, :].detach().clone().cpu()
```

This ensures:
- Zero VRAM wasted on stale device assignments between trials
- Clean CPU→target transfer regardless of how devices shuffle on reload
- No overhead on single-GPU (`.cpu()` is a no-op when already on CPU, and `.to(device)` in `ara_abliterate` handles final placement)

## Context

Hit this while running ARA on 8× RTX PRO 6000 with `device_map="auto"`. The `.to(matrix.device)` fix in d79a443 prevents the crash, but without CPU storage the captured tensors pin VRAM on devices that may get reassigned after model reload — on tight VRAM budgets this can cause OOM on subsequent trials.

## Test plan
- [x] Verified on single-GPU (`.cpu()` is no-op, `.to(device)` handles placement)
- [ ] Multi-GPU stress test with tight VRAM budget across trials