### PR TITLE
fix: prevent div-by-zero in evaluator when base_refusals is 0

### DIFF
--- a/src/heretic/evaluator.py
+++ b/src/heretic/evaluator.py
@@ -111,7 +111,7 @@ class Evaluator:
         kl_divergence_target = self.settings.kl_divergence_target
 
         refusals_score = (
-            refusals / self.base_refusals if self.base_refusals > 0 else refusals
+            refusals / self.base_refusals if self.base_refusals > 0 else float(refusals)
         )
 
         if kl_divergence >= kl_divergence_target:


### PR DESCRIPTION
As discussed in #151, splitting out the evaluator fix into its own clean PR.

  When a model refuses all prompts from the start, base_refusals is 0. The previous code would raise a ZeroDivisionError at that point. This fix returns refusals directly in that case, so ablations that
  introduce new refusals are still penalized correctly rather than crashing.

  Change:
  # Before
  refusals_score = refusals / self.base_refusals

  # After
  refusals_score = (
      refusals / self.base_refusals if self.base_refusals > 0 else refusals
  )
