### PR TITLE
fix: use separate component key for Qwen3.5 hybrid DeltaNet layers

### DIFF
--- a/src/heretic/model.py
+++ b/src/heretic/model.py
@@ -360,8 +360,9 @@ class Model:
 
         # Qwen3.5 MoE hybrid layers use GatedDeltaNet (linear attention) instead
         # of standard self-attention, so self_attn.o_proj doesn't exist on those layers.
+        # Uses a separate component key so LoRA also targets "out_proj" modules.
         with suppress(Exception):
-            try_add("attn.o_proj", layer.linear_attn.out_proj)  # ty:ignore[possibly-missing-attribute]
+            try_add("attn.out_proj", layer.linear_attn.out_proj)  # ty:ignore[possibly-missing-attribute]
 
         # Most dense models.
         with suppress(Exception):


### PR DESCRIPTION
Qwen3.5 uses a hybrid architecture with 3x DeltaNet + 1x Attention layers. DeltaNet layers use linear_attn.out_proj instead of self_attn.o_proj.

Using the same component key 'attn.o_proj' for both causes LoRA to only target 'o_proj' modules, leaving 'out_proj' unwrapped. This results in 'Linear object has no attribute base_layer' during abliteration.

Using a separate key 'attn.out_proj' ensures LoRA also targets 'out_proj' modules on DeltaNet layers.

Tested on Qwen3.5-0.8B: 4/100 refusals (from 96/100), KL divergence 0.2181.

Fixes #219