### PR TITLE
fix: "Save as LoRA adapter" option added to prompt selection

### DIFF
--- a/src/heretic/main.py
+++ b/src/heretic/main.py
@@ -108,31 +108,34 @@ def obtain_merge_strategy(settings: Settings) -> str | None:
             )
         print()
 
-        strategy = prompt_select(
-            "How do you want to proceed?",
-            choices=[
-                Choice(
-                    title="Merge LoRA into full model"
-                    + (
-                        ""
-                        if settings.quantization == QuantizationMethod.NONE
-                        else " (requires sufficient RAM)"
-                    ),
-                    value="merge",
+    strategy = prompt_select(
+        "How do you want to proceed?",
+        choices=[
+            Choice(
+                title="Merge LoRA into full model"
+                + (
+                    ""
+                    if settings.quantization == QuantizationMethod.NONE
+                    else " (requires sufficient RAM)"
                 ),
-                Choice(
-                    title="Cancel",
-                    value="cancel",
-                ),
-            ],
-        )
+                value="merge",
+            ),
+            Choice(
+                title="Save LoRA adapter",
+                value="adapter",
+            ),
+            Choice(
+                title="Cancel",
+                value="cancel",
+            ),
+        ],
+    )
 
-        if strategy == "cancel":
-            return None
+    if strategy == "cancel":
+        return None
 
-        return strategy
-    else:
-        return "merge"
+    return strategy
+
 
 
 def run():


### PR DESCRIPTION
The option of saving only the LoRA adapter was added to the obtain_merge_strategy function. Additionally, the prompt selection now shows even if the settings.quantization is not equal to QuantizationMethod.BNB_4BIT, as this might be a bug.