### PR TITLE
fix: make --help return before heavy runtime imports

### DIFF
--- a/src/heretic/main.py
+++ b/src/heretic/main.py
@@ -3,6 +3,20 @@
 
 # ruff: noqa: E402
 
+import sys
+
+from .config import Settings
+
+
+def _is_help_invocation() -> bool:
+    args = sys.argv[1:]
+    return "-h" in args or "--help" in args
+
+
+# Parse and handle CLI help before importing heavyweight ML/runtime dependencies.
+if _is_help_invocation():
+    Settings()  # ty:ignore[missing-argument]
+
 from .progress import patch_tqdm
 
 # This patches tqdm class definitions, which must happen
@@ -13,7 +27,6 @@ import logging
 import math
 import os
 import random
-import sys
 import time
 import warnings
 from dataclasses import asdict
@@ -45,7 +58,7 @@ from rich.table import Table
 from rich.traceback import install
 
 from .analyzer import Analyzer
-from .config import QuantizationMethod, Settings
+from .config import QuantizationMethod
 from .evaluator import Evaluator
 from .model import AbliterationParameters, Model, get_model_class
 from .system import empty_cache, get_accelerator_info


### PR DESCRIPTION
### Summary
---
 
This PR makes heretic --help return immediately by short-circuiting heavyweight startup.

Adds an early -h/--help check in src/heretic/main.py. If help is requested, it invokes Settings() right away so pydantic renders CLI help and exits. This path runs before importing heavy ML/runtime dependencies (torch, transformers, lm_eval, etc.). 

Normal execution flow for non-help invocations is unchanged.

