### PR TITLE
fix: prevent UnboundLocalError when analyzer is not initialized

### DIFF
--- a/src/heretic/main.py
+++ b/src/heretic/main.py
@@ -444,9 +444,8 @@ def run():
         if settings.plot_residuals:
             analyzer.plot_residuals()
 
-        # We don't need the residuals after computing refusal directions.
+        # We don't need the full residuals after computing their means and analyzing geometry.
         del good_residuals, bad_residuals, analyzer
-        empty_cache()
     else:
         print("* Obtaining residual mean for good prompts...")
         good_means = model.get_residuals_mean(good_prompts)
@@ -466,6 +465,8 @@ def run():
         )
         refusal_directions = F.normalize(refusal_directions, p=2, dim=1)
 
+    # Clear cache before starting the optimization study.
+    empty_cache()
 
     trial_index = 0
     start_index = 0

--- a/src/heretic/main.py
+++ b/src/heretic/main.py
@@ -443,6 +443,10 @@ def run():
 
         if settings.plot_residuals:
             analyzer.plot_residuals()
+
+        # We don't need the residuals after computing refusal directions.
+        del good_residuals, bad_residuals, analyzer
+        empty_cache()
     else:
         print("* Obtaining residual mean for good prompts...")
         good_means = model.get_residuals_mean(good_prompts)
@@ -462,9 +466,6 @@ def run():
         )
         refusal_directions = F.normalize(refusal_directions, p=2, dim=1)
 
-    # We don't need the residuals after computing refusal directions.
-    del good_residuals, bad_residuals, analyzer
-    empty_cache()
 
     trial_index = 0
     start_index = 0


### PR DESCRIPTION
## Summary
- Fixed an UnboundLocalError in src/heretic/main.py that occurred when the --print-residual-geometry or --plot-residuals flags were not provided.
- The issue was caused by unconditionally calling del analyzer even when analyzer was only initialized within a conditional block.
- Moved the cleanup logic (del and empty_cache()) inside the if needs_full_residuals: block.

## Test plan
- [x] Verified the fix manually by reviewing the logic in src/heretic/main.py.
- [x] Confirmed that the problematic execution path (where needs_full_residuals is False) no longer reaches the del analyzer statement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)