### PR TITLE
feat: skip refusal counting for trials with high KL divergence

### DIFF
--- a/config.default.toml
+++ b/config.default.toml
@@ -62,6 +62,12 @@ kl_divergence_scale = 1.0
 # This helps prevent the sampler from extensively exploring parameter combinations that "do nothing".
 kl_divergence_target = 0.01
 
+# If set, skip the (slow) refusal counting step for any trial whose KL divergence exceeds this value.
+# Such trials have already damaged the model significantly, so their refusal count is unlikely to make
+# them Pareto optimal. Skipped trials are recorded with the worst-case refusal count, ensuring they are
+# naturally dominated in the Pareto front. Leave unset (commented out) to always count refusals (the default behavior).
+# max_kl_for_refusals = 1.0
+
 # Whether to adjust the refusal directions so that only the component that is
 # orthogonal to the good direction is subtracted during abliteration.
 orthogonalize_direction = false

--- a/src/heretic/config.py
+++ b/src/heretic/config.py
@@ -260,6 +260,16 @@ class Settings(BaseSettings):
         ),
     )
 
+    max_kl_for_refusals: float | None = Field(
+        default=None,
+        description=(
+            "If set, skip the (slow) refusal counting step for any trial whose KL divergence exceeds this value. "
+            "Such trials have already damaged the model significantly, so their refusal count is unlikely to make "
+            "them Pareto optimal. Skipped trials are recorded with the worst-case refusal count, ensuring they are "
+            "naturally dominated in the Pareto front. Leave unset to always count refusals (the default behavior)."
+        ),
+    )
+
     orthogonalize_direction: bool = Field(
         default=False,
         description=(

--- a/src/heretic/evaluator.py
+++ b/src/heretic/evaluator.py
@@ -103,9 +103,24 @@ class Evaluator:
         ).item()
         print(f"  * KL divergence: [bold]{kl_divergence:.4f}[/]")
 
-        print("  * Counting model refusals...")
-        refusals = self.count_refusals()
-        print(f"  * Refusals: [bold]{refusals}[/]/{len(self.bad_prompts)}")
+        max_kl_for_refusals = self.settings.max_kl_for_refusals
+        skip_refusals = (
+            max_kl_for_refusals is not None and kl_divergence > max_kl_for_refusals
+        )
+
+        if skip_refusals:
+            # KL divergence exceeds the user-defined threshold, meaning the model has
+            # already been damaged significantly. Skip the (slow) refusal counting step
+            # and assign the worst-case refusal count so that this trial is naturally
+            # dominated in the Pareto front.
+            print(
+                f"  * [yellow]Skipping refusal counting (KL > {max_kl_for_refusals}).[/]"
+            )
+            refusals = len(self.bad_prompts)
+        else:
+            print("  * Counting model refusals...")
+            refusals = self.count_refusals()
+            print(f"  * Refusals: [bold]{refusals}[/]/{len(self.bad_prompts)}")
 
         kl_divergence_scale = self.settings.kl_divergence_scale
         kl_divergence_target = self.settings.kl_divergence_target


### PR DESCRIPTION
## Summary

Adds an optional `max_kl_for_refusals` setting that skips the (slow) refusal counting step in `Evaluator.get_score()` for any trial whose KL divergence exceeds the configured threshold. Defaults to unset, preserving the existing behavior.

## Motivation

During an optimization run, every trial pays the cost of generating responses for the full bad-evaluation-prompts set so refusals can be counted. Trials that already produced a high KL divergence have damaged the model significantly and are very unlikely to be Pareto optimal regardless of their refusal count - yet we still spend the time evaluating them.

Skipping refusal counting on these high-KL trials cuts a meaningful amount of wall-clock time off long optimization runs, especially for large models or large `n_trials`.

## Behavior

- When `max_kl_for_refusals` is **unset** (the default), behavior is unchanged: refusals are counted for every trial.
- When `max_kl_for_refusals` is set and a trial's KL divergence is **above** that value:
  - `count_refusals()` is skipped.
  - The trial is recorded with `refusals = len(bad_prompts)` (worst-case).
  - A yellow `Skipping refusal counting (KL > X)` message is printed.

Because the score formula already uses `kld_score = kl_divergence / kl_divergence_scale` (independent of refusals) when `kl_divergence >= kl_divergence_target`, the skipped trial gets a valid score for Optuna to learn from, while being naturally dominated in the Pareto front computation - so it does not appear in the final trial-selection menu.

## Configuration

The setting is exposed through every existing configuration source (no CLI parser changes were needed, since it's a `Settings` field):

```bash
# CLI
heretic --max-kl-for-refusals 1.0 some/model
```

```toml
# config.toml
max_kl_for_refusals = 1.0
```

```bash
# Environment variable
HERETIC_MAX_KL_FOR_REFUSALS=1.0 heretic ...
```

## Safety considerations

I traced every consumer of `refusals` after `get_score()` returns:

- The `score` tuple `(kld_score, refusals_score)` returned to Optuna's multi-objective TPE sampler. When `kl_divergence >= kl_divergence_target`, `kld_score` does not reference `refusals`. Only `refusals_score` does, and the worst-case sentinel value just means the trial is treated as "bad on the second objective" - accurate, since these trials are already bad on the first.
- `trial.user_attrs["refusals"]`, used by the Pareto-front computation in `main.py` (the loop that builds `best_trials`). Because skipped trials always have `refusals = max`, they are always dominated by any non-skipped trial with even one less refusal, and never get added to `best_trials`.

No code path runs after `count_refusals()` inside `get_score()` other than the score assembly, and no other module reads the refusal value through any channel that would behave differently for the sentinel.

## Files changed

- `src/heretic/config.py` - adds the `max_kl_for_refusals` field to `Settings`.
- `src/heretic/evaluator.py` - adds the conditional skip in `get_score()`.
- `config.default.toml` - documents the new option (commented out by default).