### PR TITLE
fix: recognize root Hugging Face repo IDs

### DIFF
--- a/src/heretic/utils.py
+++ b/src/heretic/utils.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from typing import Any, TypeVar
 
 import huggingface_hub
-from huggingface_hub.utils import HFValidationError, validate_repo_id
+from huggingface_hub.utils import validate_repo_id
 import numpy as np
 import questionary
 import tomli_w
@@ -176,11 +176,7 @@ def is_hf_path(path: str) -> bool:
     if Path(path).exists():
         return False
 
-    try:
-        validate_repo_id(path)
-    except HFValidationError:
-        return False
-
+    validate_repo_id(path)
     return True
 
 

--- a/src/heretic/utils.py
+++ b/src/heretic/utils.py
@@ -14,7 +14,6 @@ from pathlib import Path
 from typing import Any, TypeVar
 
 import huggingface_hub
-from huggingface_hub.utils import validate_repo_id
 import numpy as np
 import questionary
 import tomli_w
@@ -23,6 +22,7 @@ from datasets import DatasetDict, ReadInstruction, load_dataset, load_from_disk
 from datasets.config import DATASET_STATE_JSON_FILENAME
 from datasets.download.download_manager import DownloadMode
 from datasets.utils.info_utils import VerificationMode
+from huggingface_hub.utils import validate_repo_id
 from optuna import Trial
 from psutil import Process
 from questionary import Choice, Style
@@ -173,6 +173,8 @@ def format_duration(seconds: float) -> str:
 def is_hf_path(path: str) -> bool:
     """Checks whether a path likely refers to a Hugging Face repository."""
 
+    # Match Transformers: existing local paths take precedence over Hub lookup,
+    # even if the path string is also a valid repository ID.
     if Path(path).exists():
         return False
 

--- a/src/heretic/utils.py
+++ b/src/heretic/utils.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any, TypeVar
 
 import huggingface_hub
+from huggingface_hub.utils import HFValidationError, validate_repo_id
 import numpy as np
 import questionary
 import tomli_w
@@ -172,13 +173,15 @@ def format_duration(seconds: float) -> str:
 def is_hf_path(path: str) -> bool:
     """Checks whether a path likely refers to a Hugging Face repository."""
 
-    return (
-        not path.startswith("/")
-        and not path.endswith("/")
-        and path.count("/") == 1
-        and "\\" not in path
-        and not Path(path).exists()
-    )
+    if Path(path).exists():
+        return False
+
+    try:
+        validate_repo_id(path)
+    except HFValidationError:
+        return False
+
+    return True
 
 
 @dataclass


### PR DESCRIPTION
### Summary
- Replace the slash-count heuristic in `is_hf_path()` with Hugging Face repo ID validation.
- Keep existing local-path behavior by returning `false` when the path exists on disk.
- Recognize valid single-segment Hub IDs such as `bert-base-uncased` and `glue`.

### Why
`is_hf_path()` is used for prompt loading, reproducibility eligibility, model-card links, and reproduce-folder metadata. The current `path.count("/") == 1` check excludes valid root-level Hugging Face repository IDs, so those code paths can treat real Hub models or datasets as local paths.

Using `validate_repo_id()` keeps the helper aligned with Hugging Face's repo ID rules instead of duplicating a fragile subset of them.

### Validation
- `python3 -m py_compile src/heretic/utils.py`
- `uv run ruff check src/heretic/utils.py --fix`
- `uv run python - <<'PY' ...` smoke-tested `is_hf_path()` for root-level IDs, namespaced IDs, absolute paths, invalid multi-slash IDs, and backslash paths.
