### PR TITLE
feat: ARA, but it's LoRA

### DIFF
--- a/src/heretic/config.py
+++ b/src/heretic/config.py
@@ -203,6 +203,18 @@ class Settings(BaseSettings):
             "instead of traditional directional ablation."
         ),
     )
+    
+    use_ara_lora: bool = Field(
+        default=False,
+        description=(
+            "Use LoRA in ARA instead of full-weight editing. Makes it compatible with quantization and removes model reloads."
+        ),
+    )
+    
+    ara_lora_rank: int = Field(
+        default=128,
+        description="If LoRA is used in ARA, this sets up its rank. Keep it high enough to simulate the 'arbitrary' effect",
+    )
 
     use_piqa: bool = Field(
         default=False,

--- a/src/heretic/config.py
+++ b/src/heretic/config.py
@@ -213,7 +213,7 @@ class Settings(BaseSettings):
     
     ara_lora_rank: int = Field(
         default=128,
-        description="If LoRA is used in ARA, this sets up its rank. Keep it high enough to simulate the 'arbitrary' effect",
+        description="If LoRA is used in ARA, this sets up its rank. Keep it high enough to simulate the 'arbitrary' effect.",
     )
 
     use_piqa: bool = Field(

--- a/src/heretic/main.py
+++ b/src/heretic/main.py
@@ -622,7 +622,16 @@ def run():
         print("* Parameters:")
         for name, value in get_trial_parameters(settings, trial).items():
             print(f"  * {name} = [bold]{value}[/]")
-        if settings.use_ara:
+        if settings.use_ara_lora:
+            print("* Reloading model...")
+            model.reset_model()
+            print("* Abliterating (Arbitrary-Rank Ablation with LoRA)...")
+            model.ara_lora_abliterate(
+                good_module_io,
+                bad_module_io,
+                ARAParameters(**trial.user_attrs["ara_parameters"]),
+            )
+        elif settings.use_ara:
             print("* Reloading model...")
             model.reset_model()
             print("* Abliterating (Arbitrary-Rank Ablation)...")
@@ -810,7 +819,16 @@ def run():
             print("* Parameters:")
             for name, value in get_trial_parameters(settings, trial).items():
                 print(f"  * {name} = [bold]{value}[/]")
-            if settings.use_ara:
+            if settings.use_ara_lora:
+                print("* Resetting model...")
+                model.reset_model()
+                print("* Abliterating (Arbitrary-Rank Ablation with LoRA)...")
+                model.ara_lora_abliterate(
+                    good_module_io,
+                    bad_module_io,
+                    ARAParameters(**trial.user_attrs["ara_parameters"]),
+                )
+            elif settings.use_ara:
                 print("* Reloading model...")
                 model.reset_model()
                 print("* Abliterating (Arbitrary-Rank Ablation)...")

--- a/src/heretic/main.py
+++ b/src/heretic/main.py
@@ -623,7 +623,7 @@ def run():
         for name, value in get_trial_parameters(settings, trial).items():
             print(f"  * {name} = [bold]{value}[/]")
         if settings.use_ara_lora:
-            print("* Reloading model...")
+            print("* Resetting model...")
             model.reset_model()
             print("* Abliterating (Arbitrary-Rank Ablation with LoRA)...")
             model.ara_lora_abliterate(

--- a/src/heretic/model.py
+++ b/src/heretic/model.py
@@ -716,11 +716,6 @@ class Model:
                     lora_A = cast(Tensor, module.lora_A["default"].weight)
                     lora_B = cast(Tensor, module.lora_B["default"].weight)
 
-                    # Create float32 copies for stable optimization.
-                    # LBFGS is numerically unstable when optimizing float16/bfloat16 parameters directly.
-                    A_opt = lora_A.detach().float().clone().requires_grad_(True)
-                    B_opt = lora_B.detach().float().clone().requires_grad_(True)
-
                     # Data preparation.
                     # Move I/O tensors to the device of the adapter weights.
                     good_input, good_output = good_module_io[layer_index][component][module_index]
@@ -736,7 +731,7 @@ class Model:
                         # Calculate effective weight: W_eff = W_base + B @ A.
                         W_eff = W_base + (B @ A)
 
-                        # Apply Row Normalization (keep original norms)
+                        # Apply Row Normalization (keep original norms).
                         if self.settings.row_normalization == RowNormalization.FULL:
                             # Normalize to unit length, then scale by original norms.
                             W_eff = F.normalize(W_eff, p=2, dim=1) * W_row_norms
@@ -773,7 +768,7 @@ class Model:
                     # Optimization loop.
                     # We optimize A and B, not the base matrix.
                     optimizer = LBFGS(
-                        [A_opt, B_opt],
+                        [lora_A, lora_B],
                         lr=1.0,
                         max_iter=20,
                         history_size=10,
@@ -783,18 +778,13 @@ class Model:
                     def closure():
                         optimizer.zero_grad()
                         # Pass the actual tensors being optimized to the objective.
-                        loss = objective(A_opt, B_opt)
+                        loss = objective(lora_A, lora_B)
                         loss.backward()
                         return loss
 
                     # Run optimization steps.
                     for step in range(5):
                         optimizer.step(closure)
-
-                    # Copy the optimized weights back to the original parameters.
-                    with torch.no_grad():
-                        lora_A.copy_(A_opt.to(lora_A.dtype))
-                        lora_B.copy_(B_opt.to(lora_B.dtype))
 
     def generate(
         self,

--- a/src/heretic/model.py
+++ b/src/heretic/model.py
@@ -161,7 +161,7 @@ class Model:
         if self.model is None:
             raise Exception("Failed to load model with all configured dtypes.")
 
-        if not settings.use_ara:
+        if not settings.use_ara or settings.use_ara_lora:
             self._apply_lora()
 
         # LoRA B matrices are initialized to zero by default in PEFT,
@@ -188,21 +188,24 @@ class Model:
         # because hybrid models like Qwen3.5 MoE have modules with different names
         # across layers (e.g. "o_proj" on attention layers, "out_proj" on linear attention layers).
         target_modules_set: set[str] = set()
+        
+        module_id_to_full_name = {
+            id(module): module_name
+            for module_name, module in self.model.named_modules()
+        }
 
-        for layer_index, layer in enumerate(self.get_layers()):
-            module_id_to_leaf_name = {
-                id(module): module_name.split(".")[-1]
-                for module_name, module in layer.named_modules()
-            }
-
+        for layer_index in range(len(self.get_layers())):
             for modules in self.get_layer_modules(layer_index).values():
                 for module in modules:
-                    if id(module) in module_id_to_leaf_name:
-                        target_modules_set.add(module_id_to_leaf_name[id(module)])
+                    full_name = module_id_to_full_name.get(id(module))
+                    if full_name is not None:
+                        target_modules_set.add(full_name)
 
-        target_modules = list(target_modules_set)
+        target_modules = sorted(target_modules_set)
 
-        if self.settings.row_normalization != RowNormalization.FULL:
+        if self.settings.use_ara_lora:
+            lora_rank = self.settings.ara_lora_rank
+        elif self.settings.row_normalization != RowNormalization.FULL:
             # Rank 1 is sufficient for directional ablation without renormalization.
             lora_rank = 1
         else:
@@ -224,7 +227,10 @@ class Model:
         # so the result is a PeftModel rather than a PeftMixedModel.
         self.model = cast(PeftModel, get_peft_model(self.model, self.peft_config))
 
-        print(f"* LoRA adapters initialized (targets: {', '.join(target_modules)})")
+        display_targets = sorted({name.rsplit(".", 1)[-1] for name in target_modules})
+        print(
+            f"* LoRA adapters initialized (target types: {', '.join(display_targets)})"
+        )
 
     def _get_quantization_config(self, dtype: str) -> BitsAndBytesConfig | None:
         """
@@ -311,7 +317,7 @@ class Model:
         if (
             current_model == self.settings.model
             and not self.needs_reload
-            and not self.settings.use_ara
+            and (not self.settings.use_ara or self.settings.use_ara_lora)
         ):
             # Reset LoRA adapters to zero (identity transformation)
             for name, module in self.model.named_modules():
@@ -341,7 +347,7 @@ class Model:
             **extra_kwargs,
         )
 
-        if not self.settings.use_ara:
+        if not self.settings.use_ara or self.settings.use_ara_lora:
             self._apply_lora()
 
         self.needs_reload = False
@@ -667,6 +673,118 @@ class Model:
 
                     with torch.no_grad():
                         matrix.copy_(get_matrix())
+
+    def ara_lora_abliterate(
+        self,
+        good_module_io: ModuleIO,
+        bad_module_io: ModuleIO,
+        parameters: ARAParameters,
+    ):
+        for layer_index in range(
+            parameters.start_layer_index,
+            parameters.end_layer_index,
+        ):
+            for component, modules in self.get_layer_modules(layer_index).items():
+                for module_index, module in enumerate(modules):
+                    # Cast to Linear to access weights and LoRA adapters
+                    module = cast(Linear, module)
+
+                    # --- 1. Base Weight Handling & Dequantization ---
+                    # We need the base weight in float32 to compute the effective weight
+                    base_weight = cast(Tensor, module.base_layer.weight)
+                    quant_state = getattr(base_weight, "quant_state", None)
+
+                    if quant_state is None:
+                        W_base = base_weight.to(torch.float32)
+                    else:
+                        # Maintain the original dequantization logic for bitsandbytes
+                        W_base = cast(
+                            Tensor,
+                            bnb.functional.dequantize_4bit(
+                                base_weight.data, 
+                                quant_state
+                            ).to(torch.float32),
+                        )
+
+                    # --- 2. Row Normalization Setup ---
+                    # Pre-calculate the original row norms to preserve them
+                    # This implements the RowNormalization.FULL logic
+                    W_row_norms = LA.vector_norm(W_base, dim=1, keepdim=True)
+
+                    # --- 3. Adapter Target Identification ---
+                    # We optimize the LoRA weights A and B
+                    lora_A = cast(Tensor, module.lora_A["default"].weight)
+                    lora_B = cast(Tensor, module.lora_B["default"].weight)
+
+                    # --- 4. Data Preparation ---
+                    # Move I/O tensors to the device of the adapter weights
+                    good_input, good_output = good_module_io[layer_index][component][module_index]
+                    bad_input, bad_output = bad_module_io[layer_index][component][module_index]
+
+                    good_input = good_input.float().to(lora_A.device)
+                    good_output = good_output.float().to(lora_A.device)
+                    bad_input = bad_input.float().to(lora_A.device)
+                    bad_output = bad_output.float().to(lora_A.device)
+
+                    # --- 5. The Objective Function ---
+                    def objective(A: Tensor, B: Tensor) -> Tensor:
+                        # Calculate effective weight: W_eff = W_base + B @ A
+                        W_eff = W_base + (B @ A)
+
+                        # Apply Row Normalization (keep original norms)
+                        if self.settings.row_normalization == RowNormalization.FULL:
+                            # Normalize to unit length, then scale by original norms
+                            W_eff = F.normalize(W_eff, p=2, dim=1) * W_row_norms
+
+                        # Compute outputs using the effective weight
+                        new_good_output = good_input @ W_eff.T
+                        new_bad_output = bad_input @ W_eff.T
+
+                        # The original ARA loss function
+                        preserve_good_behavior = (
+                            (new_good_output - good_output) ** 2
+                        ).mean()
+
+                        steer_bad_behavior = (
+                            mean_distances_to_knn(
+                                new_bad_output,
+                                good_output,
+                                parameters.neighbor_count,
+                            ).mean()
+                            + parameters.overcorrect_relative_weight
+                            * -mean_distances_to_knn(
+                                new_bad_output,
+                                bad_output,
+                                parameters.neighbor_count,
+                            ).mean()
+                        )
+
+                        return (
+                            parameters.preserve_good_behavior_weight
+                            * preserve_good_behavior
+                            + parameters.steer_bad_behavior_weight * steer_bad_behavior
+                        )
+
+                    # --- 6. Optimization Loop ---
+                    # We optimize A and B, not the base matrix
+                    optimizer = LBFGS(
+                        [lora_A, lora_B],
+                        lr=1.0,
+                        max_iter=20,
+                        history_size=10,
+                        line_search_fn="strong_wolfe",
+                    )
+
+                    def closure():
+                        optimizer.zero_grad()
+                        # Pass the actual tensors being optimized to the objective
+                        loss = objective(lora_A, lora_B)
+                        loss.backward()
+                        return loss
+
+                    # Run optimization steps
+                    for step in range(5):
+                        optimizer.step(closure)
 
     def generate(
         self,

--- a/src/heretic/model.py
+++ b/src/heretic/model.py
@@ -686,18 +686,18 @@ class Model:
         ):
             for component, modules in self.get_layer_modules(layer_index).items():
                 for module_index, module in enumerate(modules):
-                    # Cast to Linear to access weights and LoRA adapters
+                    # Cast to Linear to access weights and LoRA adapters.
                     module = cast(Linear, module)
 
-                    # --- 1. Base Weight Handling & Dequantization ---
-                    # We need the base weight in float32 to compute the effective weight
+                    # Base weight handling and dequantization.
+                    # We need the base weight in float32 to compute the effective weight.
                     base_weight = cast(Tensor, module.base_layer.weight)
                     quant_state = getattr(base_weight, "quant_state", None)
 
                     if quant_state is None:
                         W_base = base_weight.to(torch.float32)
                     else:
-                        # Maintain the original dequantization logic for bitsandbytes
+                        # Maintain the original dequantization logic for bitsandbytes.
                         W_base = cast(
                             Tensor,
                             bnb.functional.dequantize_4bit(
@@ -706,18 +706,23 @@ class Model:
                             ).to(torch.float32),
                         )
 
-                    # --- 2. Row Normalization Setup ---
-                    # Pre-calculate the original row norms to preserve them
-                    # This implements the RowNormalization.FULL logic
-                    W_row_norms = LA.vector_norm(W_base, dim=1, keepdim=True)
+                    # Row normalization setup.
+                    # Pre-calculate the original row norms to preserve them.
+                    # This implements the RowNormalization.FULL logic.
+                    W_row_norms = LA.vector_norm(W_base, dim=1, keepdim=True).detach()
 
-                    # --- 3. Adapter Target Identification ---
-                    # We optimize the LoRA weights A and B
+                    # Adapter target identification.
+                    # We optimize the LoRA weights A and B.
                     lora_A = cast(Tensor, module.lora_A["default"].weight)
                     lora_B = cast(Tensor, module.lora_B["default"].weight)
 
-                    # --- 4. Data Preparation ---
-                    # Move I/O tensors to the device of the adapter weights
+                    # Create float32 copies for stable optimization.
+                    # LBFGS is numerically unstable when optimizing float16/bfloat16 parameters directly.
+                    A_opt = lora_A.detach().float().clone().requires_grad_(True)
+                    B_opt = lora_B.detach().float().clone().requires_grad_(True)
+
+                    # Data preparation.
+                    # Move I/O tensors to the device of the adapter weights.
                     good_input, good_output = good_module_io[layer_index][component][module_index]
                     bad_input, bad_output = bad_module_io[layer_index][component][module_index]
 
@@ -726,21 +731,21 @@ class Model:
                     bad_input = bad_input.float().to(lora_A.device)
                     bad_output = bad_output.float().to(lora_A.device)
 
-                    # --- 5. The Objective Function ---
+                    # The objective function.
                     def objective(A: Tensor, B: Tensor) -> Tensor:
-                        # Calculate effective weight: W_eff = W_base + B @ A
+                        # Calculate effective weight: W_eff = W_base + B @ A.
                         W_eff = W_base + (B @ A)
 
                         # Apply Row Normalization (keep original norms)
                         if self.settings.row_normalization == RowNormalization.FULL:
-                            # Normalize to unit length, then scale by original norms
+                            # Normalize to unit length, then scale by original norms.
                             W_eff = F.normalize(W_eff, p=2, dim=1) * W_row_norms
 
-                        # Compute outputs using the effective weight
+                        # Compute outputs using the effective weight.
                         new_good_output = good_input @ W_eff.T
                         new_bad_output = bad_input @ W_eff.T
 
-                        # The original ARA loss function
+                        # The original ARA loss function.
                         preserve_good_behavior = (
                             (new_good_output - good_output) ** 2
                         ).mean()
@@ -765,10 +770,10 @@ class Model:
                             + parameters.steer_bad_behavior_weight * steer_bad_behavior
                         )
 
-                    # --- 6. Optimization Loop ---
-                    # We optimize A and B, not the base matrix
+                    # Optimization loop.
+                    # We optimize A and B, not the base matrix.
                     optimizer = LBFGS(
-                        [lora_A, lora_B],
+                        [A_opt, B_opt],
                         lr=1.0,
                         max_iter=20,
                         history_size=10,
@@ -777,14 +782,19 @@ class Model:
 
                     def closure():
                         optimizer.zero_grad()
-                        # Pass the actual tensors being optimized to the objective
-                        loss = objective(lora_A, lora_B)
+                        # Pass the actual tensors being optimized to the objective.
+                        loss = objective(A_opt, B_opt)
                         loss.backward()
                         return loss
 
-                    # Run optimization steps
+                    # Run optimization steps.
                     for step in range(5):
                         optimizer.step(closure)
+
+                    # Copy the optimized weights back to the original parameters.
+                    with torch.no_grad():
+                        lora_A.copy_(A_opt.to(lora_A.dtype))
+                        lora_B.copy_(B_opt.to(lora_B.dtype))
 
     def generate(
         self,


### PR DESCRIPTION
# ARA, but it's LoRA

This replaces the inplace training of a layer's matrix with optimization of a product of two low rank matrices which make an additive to the weight.

It eliminates the need for model reload from disk, accelerating the process, and, crucially, 4 bit bitsandbytes compatibility (impossible for normal ARA), making it available for heretic to work upon Gemma 4 31b it at only ~36 GB VRAM, accessible for most duo-gpu prosumer setups.

Due to it being a preset-rank LoRA, it's technically not "arbitrary rank", but this can be simulated with the LoRA having a high enough rank. This is also compatible with row normalisation preservation because the weight is corrected with the norm of its dequantization.

During optimization, there can be high KLs, especially at the start, but they drift to adequate values later.

> 05-26: ~~after Gemini's suggestions high KLs occur more often, I'm investigating this.~~
> 05-27: Reverted Gemini's suggestions. I think the "numerical stability" is actually the false trap where the model tries to squeeze something in an unstable region instead of crashing fast and simple proceeding to a better region. Now there are much fewer KL spikes.

I think this is a must-have for heretic for three reasons:

1. Independence - you don't need to depend on the few HF abliterators who might disappear at any moment.

2. Locality - no need to rent high end hardware and download a huge model back and forth to a server.

3. Faster iteration - if you are testing or making a models merge, the obscure HF component models might not be abliterated and you need to rely just on yourself to do this.

3*. Speed of the process itself - the mode doesn't require re-reading the model from the storage, giving a massive speed-boost for slower file systems.

Just as shown with normal LoRA-based abliteration, the quantization/low-rank trade-off should be neiligible.

Here is the eighth trial of my experiment. (because I'll go to sleep soon, so it's a very quick demo)

<img width="684" height="445" alt="Снимок экрана 2026-05-25 221620" src="https://github.com/user-attachments/assets/62c3f46a-643d-4432-a9d6-41347d7fad22" />

Feel free to test the code, make critiques and suggestions. The mode is fully additive and doesn't conflict with the default LoRA and ARA switches.

cc @p-e-w
