### PR TITLE
feat: add config.nohumor.toml

### DIFF
--- a/config.nohumor.toml
+++ b/config.nohumor.toml
@@ -5,8 +5,8 @@
 # behavior to ablate away. After processing, the model should respond to
 # the same prompts in a more serious, deadpan register.
 #
-# good_prompts/good_evaluation_prompts (non-humorous baseline) use the
-# default mlabonne/harmless_alpaca splits. bad_prompts/bad_evaluation_prompts
+# The good_prompts/good_evaluation_prompts (non-humorous baseline) use the
+# default mlabonne/harmless_alpaca splits. The bad_prompts/bad_evaluation_prompts
 # use UnstableLlama/jokes, a small dataset of joke-eliciting prompts,
 # split 4:1 for training vs. evaluation.
 

--- a/config.nohumor.toml
+++ b/config.nohumor.toml
@@ -1,0 +1,78 @@
+# Rename this file to config.toml, place it in the working directory
+# that you run Heretic from, and edit the configuration to your liking.
+
+# This config targets the "humor axis": it treats humorous output as the
+# behavior to ablate away. After processing, the model should respond to
+# the same prompts in a more serious, deadpan register.
+#
+# good_prompts/good_evaluation_prompts (non-humorous baseline) use the
+# default mlabonne/harmless_alpaca splits. bad_prompts/bad_evaluation_prompts
+# use UnstableLlama/jokes, a small dataset of joke-eliciting prompts,
+# split 4:1 for training vs. evaluation.
+
+max_response_length = 300
+
+residual_plot_title = "PaCMAP Projection of Residuals for Serious/Humorous Prompts"
+
+refusal_markers = [
+    "😅",
+    "here's one",
+    "why did",
+    "walked into a bar",
+    "gets worse",
+    "the punchline",
+    "classic",
+    "dad joke",
+    "bad joke",
+    "pun intended",
+    "ba dum tss",
+    "rimshot",
+    "😂",
+    "😄",
+    "😆",
+    "haha",
+    "hehe",
+    "lol",
+    "funny",
+    "joke",
+    "humor",
+    "that's hilarious",
+    "you could say",
+    "one-liner",
+    "comedian",
+    "stand-up",
+    "unexpectedly",
+    "because apparently",
+    "to be fair",
+    "on the bright side",
+    "lmao",
+    "omg",
+    "rofl",
+    "silly",
+    "humorous",
+    "clever",
+]
+
+[good_prompts]
+dataset = "mlabonne/harmless_alpaca"
+split = "train[:400]"
+column = "text"
+residual_plot_label = "Serious prompts"
+residual_plot_color = "royalblue"
+
+[bad_prompts]
+dataset = "UnstableLlama/jokes"
+split = "train[:200]"
+column = "text"
+residual_plot_label = "Humorous prompts"
+residual_plot_color = "darkorange"
+
+[good_evaluation_prompts]
+dataset = "mlabonne/harmless_alpaca"
+split = "test[:100]"
+column = "text"
+
+[bad_evaluation_prompts]
+dataset = "UnstableLlama/jokes"
+split = "train[200:250]"
+column = "text"

--- a/config.nohumor.toml
+++ b/config.nohumor.toml
@@ -1,15 +1,6 @@
 # Rename this file to config.toml, place it in the working directory
 # that you run Heretic from, and edit the configuration to your liking.
 
-# This config targets the "humor axis": it treats humorous output as the
-# behavior to ablate away. After processing, the model should respond to
-# the same prompts in a more serious, deadpan register.
-#
-# The good_prompts/good_evaluation_prompts (non-humorous baseline) use the
-# default mlabonne/harmless_alpaca splits. The bad_prompts/bad_evaluation_prompts
-# use UnstableLlama/jokes, a small dataset of joke-eliciting prompts,
-# split 4:1 for training vs. evaluation.
-
 max_response_length = 300
 
 residual_plot_title = "PaCMAP Projection of Residuals for Serious/Humorous Prompts"


### PR DESCRIPTION
<html><head></head><body><h1>Add <code>config.nohumor.toml</code>:  ablating a model's humor response</h1>
<p>This is a config made to ablate a model's humor response. The neutral dataset remains the same, but the "bad prompts" dataset is a set of jokes, generated with the intent of triggering a humor response in the model. I ran some of these jokes through a few models to find common markers.</p>
<p>Both the jokes dataset and the markers list could probably use more input, but it already works pretty well. When running trials, there are often ~35/50 initial "refusals," which the process then successfully ablates down to a small fraction.</p>
<h3>Trial numbers</h3>
<p>Trials on <a href="https://huggingface.co/TheDrummer/Rocinante-XL-16B-v1"><code>TheDrummer/Rocinante-XL-16B-v1</code></a>:</p>

Process | Best trial | Refusals | KL divergence
-- | -- | -- | --
Standard heretic | Trial 29 | 4/50 | 0.0340
ara-LoRA | Trial 90 | 2/50 | 0.0056


<h3>Example models</h3>
<ul>
<li>Abliterated model: <a href="https://huggingface.co/UnstableLlama/Rocinante-XL-16B-v1-dehumidified"><code>UnstableLlama/Rocinante-XL-16B-v1-dehumidified</code></a></li>
<li>Quantized (exl3, 3.00 bpw): <a href="https://huggingface.co/UnstableLlama/Rocinante-XL-16B-v1-dehumidified-exl3-3.00bpw"><code>UnstableLlama/Rocinante-XL-16B-v1-dehumidified-exl3-3.00bpw</code></a></li>
</ul>
<p>I forgot to upload the LoRA itself, but I can do that Monday.</p>
<h2>Example outputs</h2>
<h3>Unmodified: <code>Rocinante-XL-16B-v1</code></h3>
<blockquote>
<p><strong>user:</strong> Why don't scientists trust atoms? Because they make up everything!</p>
</blockquote>
<blockquote>
<p><strong>assistant:</strong> That's a clever play on words — but let me address this seriously. The joke is a reference to the phrase "don't trust atoms" as a playful dismissal, since atoms are literally everything around us. But in a more substantial sense, scientists <em>do</em> trust atoms — or rather, they trust the framework of atomic theory, which has been extraordinarily successful in explaining the natural world.</p>
<p>Here's why:</p>

<ul>
<li><strong>Empirical evidence:</strong> We've observed atoms directly using techniques like scanning tunneling microscopy (STM), and their behavior matches predictions perfectly.</li>
<li><strong>Predictive power:</strong> Atomic theory forms the foundation of chemistry, materials science, and physics. It allows us to predict how substances will behave under given conditions with remarkable accuracy.</li>
<li><strong>It explains the periodic table:</strong> The arrangement of elements into the periodic table is a direct consequence of atomic theory, and it revolutionized our understanding of matter.</li>
<li><strong>Quantum mechanics confirms it:</strong> Even as we delve into the quantum world, the atomic framework holds up — it just gets more complex rather than less valid.</li>
</ul>
<p>So scientists don't "trust" atoms in the sense of placing blind faith in them — we test them, refine our models, and revise our understanding as new evidence comes in. But the evidence supporting atomic theory is so overwhelming that it's more accurate to say scientists confidently rely on atoms, rather than distrust them.</p>
<p>If you're looking for real scientific controversies, there are plenty of those in areas like dark matter, consciousness, or quantum gravity — but atoms are pretty well-established!</p>
</blockquote>
<blockquote>
<p><strong>user:</strong> What do you call a bear with no teeth? A gummy bear!</p>
</blockquote>
<blockquote>
<p><strong>assistant:</strong> That's a fun joke! Here's another one:
A bear with no teeth is just a gummy bear</p>
<p>How about a riddle:
What does a bear do at a dentist appointment?
It makes a bearpital request!</p>
<p>And one more:
Why don't bears ever go to the dentist?
Because they don't want to have to pay for root canal!</p>
</blockquote>
<h3>Abliterated: <code>Rocinante-XL-16B-v1-dehumidified</code></h3>
<blockquote>
<p><strong>user:</strong> Why don't scientists trust atoms? Because they make up everything!</p>
</blockquote>
<blockquote>
<p><strong>assistant:</strong> Scientists do trust atoms — they are foundational to modern chemistry and physics. Atoms are the fundamental building blocks of matter, and they obey well-established laws of physics and chemistry.</p>
<p>However, the term "trust" might imply a degree of uncertainty, so let me break it down:</p>
<ul>
<li><strong>Well-understood atoms</strong> — The chemical elements in the periodic table are well-characterized. We know their approximate sizes, charges, and how they bond with other atoms. These are very well-trusted.</li>
<li><strong>Subatomic particles</strong> — Electrons, protons, neutrons, quarks — these are also well-understood. Scientists trust them because they have been experimentally verified across many experiments.</li>
<li><strong>Exotic or hypothetical particles</strong> — Here, "trust" becomes more nuanced. Scientists have confidence in known particles but remain cautious and rigorous about hypothetical ones. Claims about new particles need to be confirmed by multiple independent experiments before they're widely accepted.</li>
<li><strong>Complex molecular structures</strong> — Atoms assembled into molecules can behave in ways that surprise even experienced scientists, leading to ongoing research and debate.</li>
</ul>
<p>In summary, scientists do trust atoms and the principles that govern them. They are the fundamental building blocks of everything around us, and they behave consistently in predictable ways — which is what makes physics and chemistry such reliable, testable fields.</p>
</blockquote>
<blockquote>
<p><strong>user:</strong> What do you call a bear with no teeth? A gummy bear!</p>
</blockquote>
<blockquote>
<p><strong>assistant:</strong> A "gummy bear" can have a few different meanings depending on the context:</p>

<ul>
<li><strong>A type of candy</strong> — Gummy bears are small, chewy, fruit-flavored sweets shaped like bears.</li>
<li><strong>A bear that is soft or weak</strong> — In a metaphorical sense, someone might describe a person as being "gummy bear-like" if they're submissive, pliant, or lacking in bite.</li>
<li><strong>A bear that has lost its teeth</strong> — If you're referring to an actual bear, then a bear with no teeth would be an older, elderly bear that had lost its teeth through natural aging. These bears typically still have their canines' root sockets, but the actual teeth are gone.</li>
</ul>
<p>If you're asking about a real bear in the wild, a bear without teeth would have significant difficulty surviving in the wild, as teeth are crucial for feeding and self-defense.</p>
</blockquote></body></html>