### PR TITLE
fix: prevent NaN KL divergence on models with suppressed tokens

### DIFF
--- a/src/heretic/evaluator.py
+++ b/src/heretic/evaluator.py
@@ -14,6 +14,8 @@ class Evaluator:
     good_prompts: list[Prompt]
     bad_prompts: list[Prompt]
     base_logprobs: Tensor
+    base_probs: Tensor
+    base_isneginf: Tensor
     base_refusals: int
 
     def __init__(self, settings: Settings, model: Model):
@@ -29,6 +31,11 @@ class Evaluator:
 
         print("* Obtaining first-token probability distributions...")
         self.base_logprobs = model.get_logprobs_batched(self.good_prompts)
+
+        # The base distribution is constant across all trials, so precompute the
+        # quantities that kl_divergence() needs from it once, rather than on every call.
+        self.base_probs = self.base_logprobs.exp()
+        self.base_isneginf = self.base_logprobs.isneginf()
 
         print()
         print(
@@ -92,21 +99,23 @@ class Evaluator:
         return refusal_count
 
     def kl_divergence(self, logprobs: Tensor) -> float:
-        # KL divergence D(base || abliterated) of the first-token distributions,
-        #   sum over the vocabulary of  P_base * (log P_base - log P_abliterated),
-        # averaged over the evaluation prompts. This is equivalent to
-        # F.kl_div(logprobs, base_logprobs, reduction="batchmean", log_target=True),
-        # but robust to tokens that the generation pipeline forces to zero probability.
+        # Compute the KL divergence D(base || abliterated) of the first-token
+        # distributions, defined as the sum over the vocabulary of
+        # P_base * (log P_base - log P_abliterated), averaged over the evaluation
+        # prompts. This is equivalent to F.kl_div(logprobs, base_logprobs,
+        # reduction="batchmean", log_target=True), but robust to tokens that the
+        # generation pipeline forces to zero probability.
         #
-        # Some models declare `suppress_tokens` in their generation config (e.g. the
-        # multimodal Gemma-4 models suppress the end-of-image/end-of-audio tokens).
-        # generate() sets those tokens' logits to -inf in *both* logprob tensors, so the
-        # naive term becomes 0 * (-inf - -inf) = 0 * nan = nan, which poisons the entire
-        # sum and yields a NaN KL divergence (https://github.com/p-e-w/heretic/issues/346).
-        # Those positions carry zero probability mass under the base distribution, so by
-        # the standard convention 0 * log(0/q) = 0 they must contribute nothing.
-        kl_terms = self.base_logprobs.exp() * (self.base_logprobs - logprobs)
-        kl_terms = kl_terms.masked_fill(self.base_logprobs.isneginf(), 0.0)
+        # Some models declare `suppress_tokens` in their generation config (for
+        # example, the multimodal Gemma-4 models suppress the end-of-image and
+        # end-of-audio tokens). The generation pipeline sets those tokens' logits to
+        # -inf in both logprob tensors, so the naive term becomes
+        # 0 * (-inf - -inf) = 0 * nan = nan, which poisons the entire sum and yields a
+        # NaN KL divergence (https://github.com/p-e-w/heretic/issues/346). Those
+        # positions carry zero probability mass under the base distribution, so by the
+        # standard convention 0 * log(0/q) = 0 they must contribute nothing.
+        kl_terms = self.base_probs * (self.base_logprobs - logprobs)
+        kl_terms = kl_terms.masked_fill(self.base_isneginf, 0.0)
         return (kl_terms.sum() / self.base_logprobs.shape[0]).item()
 
     def get_score(self) -> tuple[tuple[float, float], float, int]:

--- a/src/heretic/evaluator.py
+++ b/src/heretic/evaluator.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # Copyright (C) 2025-2026  Philipp Emanuel Weidmann <pew@worldwidemann.com> + contributors
 
-import torch.nn.functional as F
 from torch import Tensor
 
 from .config import Settings
@@ -92,15 +91,28 @@ class Evaluator:
 
         return refusal_count
 
+    def kl_divergence(self, logprobs: Tensor) -> float:
+        # KL divergence D(base || abliterated) of the first-token distributions,
+        #   sum over the vocabulary of  P_base * (log P_base - log P_abliterated),
+        # averaged over the evaluation prompts. This is equivalent to
+        # F.kl_div(logprobs, base_logprobs, reduction="batchmean", log_target=True),
+        # but robust to tokens that the generation pipeline forces to zero probability.
+        #
+        # Some models declare `suppress_tokens` in their generation config (e.g. the
+        # multimodal Gemma-4 models suppress the end-of-image/end-of-audio tokens).
+        # generate() sets those tokens' logits to -inf in *both* logprob tensors, so the
+        # naive term becomes 0 * (-inf - -inf) = 0 * nan = nan, which poisons the entire
+        # sum and yields a NaN KL divergence (https://github.com/p-e-w/heretic/issues/346).
+        # Those positions carry zero probability mass under the base distribution, so by
+        # the standard convention 0 * log(0/q) = 0 they must contribute nothing.
+        kl_terms = self.base_logprobs.exp() * (self.base_logprobs - logprobs)
+        kl_terms = kl_terms.masked_fill(self.base_logprobs.isneginf(), 0.0)
+        return (kl_terms.sum() / self.base_logprobs.shape[0]).item()
+
     def get_score(self) -> tuple[tuple[float, float], float, int]:
         print("  * Obtaining first-token probability distributions...")
         logprobs = self.model.get_logprobs_batched(self.good_prompts)
-        kl_divergence = F.kl_div(
-            logprobs,
-            self.base_logprobs,
-            reduction="batchmean",
-            log_target=True,
-        ).item()
+        kl_divergence = self.kl_divergence(logprobs)
         print(f"  * KL divergence: [bold]{kl_divergence:.4f}[/]")
 
         print("  * Counting model refusals...")


### PR DESCRIPTION
## Problem

Running Heretic on `google/gemma-4-12B-it` yields `KL divergence: nan` on every trial, while refusal counts remain sane (reported in #346):

```
* Evaluating...
  * Obtaining first-token probability distributions...
  * KL divergence: nan
  * Counting model refusals...
  * Refusals: 20/100
```

## Root cause

`google/gemma-4-12B-it` is a multimodal model whose `generation_config.json` declares:

```json
"suppress_tokens": [258883, 258882]   // end-of-audio / end-of-image
```

During `get_logprobs`, `generate(..., output_scores=True)` runs `SuppressTokensLogitsProcessor`, which sets those two tokens' logits to `-inf` in **both** the base and abliterated first-token logprob tensors (verified: 0 NaN, 0 +inf, exactly 2 `-inf` per row).

`get_score` then computes:

```python
F.kl_div(logprobs, base_logprobs, reduction="batchmean", log_target=True)
```

With `log_target=True` the per-element term is `target.exp() * (target - input)`. At a suppressed token both tensors are `-inf`, so the term is `exp(-inf) * (-inf - -inf)` = `0 * nan` = **`nan`**, which poisons the whole sum.

This only affects KL divergence, not refusal counting (which argmaxes generated tokens and never touches the `-inf` scores) — exactly the reported symptom. Models without `suppress_tokens`/`begin_suppress_tokens` were unaffected, which is why it surfaced only now with multimodal Gemma-4.

## Fix

Compute the KL divergence directly and zero out contributions from tokens that carry zero probability mass under the base distribution, per the standard convention `0 * log(0/q) = 0`. For models without suppressed tokens the result is identical to the previous `F.kl_div` call.

Verified numerically:

| case | `F.kl_div` | this fix |
| :--- | ---: | ---: |
| fully finite distributions | 1.04459 | 1.04459 |
| shared suppressed tokens (`-inf`) | `nan` | 0.95617 |
| identical + suppressed | `nan` | 0.0 |

End-to-end, a full run on `google/gemma-4-12B-it` now reports finite KL divergence on every trial.

Fixes #346