### PR TITLE
feat: save processor for multimodal models

### DIFF
--- a/src/heretic/main.py
+++ b/src/heretic/main.py
@@ -813,6 +813,8 @@ def run():
                                 del merged_model
                                 empty_cache()
                                 model.tokenizer.save_pretrained(save_directory)
+                                if model.processor is not None:
+                                    model.processor.save_pretrained(save_directory)
                                 reset_trial_model()
 
                             print(f"Model saved to [bold]{save_directory}[/].")
@@ -923,6 +925,12 @@ def run():
                                     private=private,
                                     token=token,
                                 )
+                                if model.processor is not None:
+                                    model.processor.push_to_hub(
+                                        repo_id,
+                                        private=private,
+                                        token=token,
+                                    )
                                 reset_trial_model()
 
                             if is_hf_path(settings.model):

--- a/src/heretic/model.py
+++ b/src/heretic/model.py
@@ -17,6 +17,7 @@ from torch.nn import Module, ModuleList
 from transformers import (
     AutoModelForCausalLM,
     AutoModelForImageTextToText,
+    AutoProcessor,
     AutoTokenizer,
     BatchEncoding,
     BitsAndBytesConfig,
@@ -56,6 +57,8 @@ class AbliterationParameters:
 class Model:
     model: PreTrainedModel | PeftModel
     tokenizer: PreTrainedTokenizerBase
+    # Set for multimodal models, None for text-only ones.
+    processor: Any | None
     peft_config: LoraConfig
 
     def __init__(self, settings: Settings):
@@ -74,6 +77,15 @@ class Model:
             trust_remote_code=settings.trust_remote_code,
             **self.revision_kwargs,
         )
+
+        # Multimodal models have a processor we'll want to save; text-only ones raise here.
+        self.processor = None
+        with suppress(Exception):
+            self.processor = AutoProcessor.from_pretrained(
+                settings.model,
+                trust_remote_code=settings.trust_remote_code,
+                **self.revision_kwargs,
+            )
 
         # Fallback for tokenizers that don't declare a special pad token.
         if self.tokenizer.pad_token is None:

--- a/src/heretic/model.py
+++ b/src/heretic/model.py
@@ -24,6 +24,7 @@ from transformers import (
     PretrainedConfig,
     PreTrainedModel,
     PreTrainedTokenizerBase,
+    ProcessorMixin,
     TextStreamer,
 )
 from transformers.generation import (
@@ -58,7 +59,7 @@ class Model:
     model: PreTrainedModel | PeftModel
     tokenizer: PreTrainedTokenizerBase
     # Set for multimodal models, None for text-only ones.
-    processor: Any | None
+    processor: ProcessorMixin | None
     peft_config: LoraConfig
 
     def __init__(self, settings: Settings):

--- a/src/heretic/model.py
+++ b/src/heretic/model.py
@@ -78,9 +78,9 @@ class Model:
             **self.revision_kwargs,
         )
 
-        # Multimodal models have a processor we'll want to save; text-only ones raise here.
+        # Multimodal models have a processor we'll want to save.
         self.processor = None
-        with suppress(Exception):
+        if get_model_class(settings.model) == AutoModelForImageTextToText:
             self.processor = AutoProcessor.from_pretrained(
                 settings.model,
                 trust_remote_code=settings.trust_remote_code,


### PR DESCRIPTION
VL models (Gemma 3/4, Qwen-VL, etc.) load via AutoModelForImageTextToText (added in #108), but only the tokenizer was ever saved/pushed. 

The processor, which holds the image/audio preprocessing config (preprocessor_config.json, processor_config.json) was dropped, so the saved/uploaded abliterated model could no longer be loaded with AutoProcessor and was unusable for its multimodal inputs.

Load the processor alongside the tokenizer (None for text-only models, where AutoProcessor.from_pretrained raises) and save/push it wherever the tokenizer is saved/pushed. Abliteration itself is unchanged, it only touches the text path; this just keeps the resulting model complete.