### PR TITLE
fix: resolve variable shadowing of error in ValidationError handler

### DIFF
--- a/src/heretic/main.py
+++ b/src/heretic/main.py
@@ -195,8 +195,10 @@ def run():
     except ValidationError as error:
         print(f"[red]Configuration contains [bold]{error.error_count()}[/] errors:[/]")
 
-        for error in error.errors():
-            print(f"[bold]{error['loc'][0]}[/]: [yellow]{error['msg']}[/]")
+        for error_detail in error.errors():
+            print(
+                f"[bold]{error_detail['loc'][0]}[/]: [yellow]{error_detail['msg']}[/]"
+            )
 
         print()
         print(


### PR DESCRIPTION
Hi there,

I noticed a minor code quality / variable shadowing issue in the `ValidationError` exception handler inside `src/heretic/main.py`.

### The Problem
The variable `error` is bound to the caught exception object:
```python
except ValidationError as error:
However, inside that block, the loop variable reuses the exact same variable name:
    for error in error.errors():
In Python, this rebinds the local variable error to a dictionary on the very first iteration of the loop, destroying the reference to the original exception object. While it works right now because the loop body doesn't need the exception object anymore, this shadowing pattern is a correctness hazard and makes future refactoring brittle.

The Solution
I renamed the loop variable from error to err to resolve the shadowing and keep the scope clean.

Thanks for taking a look!