### PR TITLE
fix: improve exception formatting (#146)

### DIFF
--- a/src/heretic/main.py
+++ b/src/heretic/main.py
@@ -69,6 +69,7 @@ from .reproduce import collect_reproducibles
 from .system import empty_cache, get_accelerator_info
 from .utils import (
     format_duration,
+    format_exception,
     get_readme_intro,
     get_trial_parameters,
     is_hf_path,
@@ -364,7 +365,7 @@ def run():
                     # We cannot recover from this.
                     raise
 
-                print(f"[red]Failed[/] ({str(error).strip() or type(error).__name__})")
+                print(f"[red]Failed[/] ({format_exception(error)})")
                 break
 
             response_lengths = [
@@ -1120,9 +1121,7 @@ def run():
                                 print(table)
 
                 except Exception as error:
-                    print(
-                        f"[red]Error: {str(error).strip() or type(error).__name__}[/]"
-                    )
+                    print(f"[red]Error: {format_exception(error)}[/]")
 
 
 def main():

--- a/src/heretic/main.py
+++ b/src/heretic/main.py
@@ -365,7 +365,11 @@ def run():
                     # We cannot recover from this.
                     raise
 
-                print(f"[red]Failed[/] ({format_exception(error)})")
+                formatted = format_exception(error)
+                if "\n" in formatted:
+                    print(f"[red]Failed[/]:{formatted}")
+                else:
+                    print(f"[red]Failed[/] ({formatted})")
                 break
 
             response_lengths = [

--- a/src/heretic/main.py
+++ b/src/heretic/main.py
@@ -364,7 +364,7 @@ def run():
                     # We cannot recover from this.
                     raise
 
-                print(f"[red]Failed[/] ({error})")
+                print(f"[red]Failed[/] ({str(error).strip() or type(error).__name__})")
                 break
 
             response_lengths = [
@@ -1120,7 +1120,9 @@ def run():
                                 print(table)
 
                 except Exception as error:
-                    print(f"[red]Error: {error}[/]")
+                    print(
+                        f"[red]Error: {str(error).strip() or type(error).__name__}[/]"
+                    )
 
 
 def main():

--- a/src/heretic/main.py
+++ b/src/heretic/main.py
@@ -367,7 +367,7 @@ def run():
 
                 formatted = format_exception(error)
                 if "\n" in formatted:
-                    print(f"[red]Failed[/]:{formatted}")
+                    print(f"[red]Failed[/]:\n{formatted}")
                 else:
                     print(f"[red]Failed[/] ({formatted})")
                 break
@@ -1125,7 +1125,11 @@ def run():
                                 print(table)
 
                 except Exception as error:
-                    print(f"[red]Error: {format_exception(error)}[/]")
+                    formatted = format_exception(error)
+                    if "\n" in formatted:
+                        print(f"[red]Error:[/]\n{formatted}")
+                    else:
+                        print(f"[red]Error: {formatted}[/]")
 
 
 def main():

--- a/src/heretic/model.py
+++ b/src/heretic/model.py
@@ -152,7 +152,7 @@ class Model:
                 empty_cache()
                 formatted = format_exception(error)
                 if "\n" in formatted:
-                    print(f"* [red]Failed[/]:{formatted}")
+                    print(f"* [red]Failed[/]:\n{formatted}")
                 else:
                     print(f"* [red]Failed[/] ({formatted})")
                 continue

--- a/src/heretic/model.py
+++ b/src/heretic/model.py
@@ -150,7 +150,11 @@ class Model:
             except Exception as error:
                 self.model = None  # ty:ignore[invalid-assignment]
                 empty_cache()
-                print(f"* [red]Failed[/] ({format_exception(error)})")
+                formatted = format_exception(error)
+                if "\n" in formatted:
+                    print(f"* [red]Failed[/]:{formatted}")
+                else:
+                    print(f"* [red]Failed[/] ({formatted})")
                 continue
 
             if settings.quantization == QuantizationMethod.BNB_4BIT:

--- a/src/heretic/model.py
+++ b/src/heretic/model.py
@@ -33,7 +33,7 @@ from transformers.generation import (
 
 from .config import QuantizationMethod, RowNormalization, Settings
 from .system import empty_cache
-from .utils import Prompt, batchify, print
+from .utils import Prompt, batchify, format_exception, print
 
 
 def get_model_class(
@@ -150,9 +150,7 @@ class Model:
             except Exception as error:
                 self.model = None  # ty:ignore[invalid-assignment]
                 empty_cache()
-                print(
-                    f"* [red]Failed[/] ({str(error).strip() or type(error).__name__})"
-                )
+                print(f"* [red]Failed[/] ({format_exception(error)})")
                 continue
 
             if settings.quantization == QuantizationMethod.BNB_4BIT:

--- a/src/heretic/model.py
+++ b/src/heretic/model.py
@@ -150,7 +150,9 @@ class Model:
             except Exception as error:
                 self.model = None  # ty:ignore[invalid-assignment]
                 empty_cache()
-                print(f"* [red]Failed[/] ({error})")
+                print(
+                    f"* [red]Failed[/] ({str(error).strip() or type(error).__name__})"
+                )
                 continue
 
             if settings.quantization == QuantizationMethod.BNB_4BIT:

--- a/src/heretic/utils.py
+++ b/src/heretic/utils.py
@@ -759,4 +759,4 @@ def format_exception(error: Exception) -> str:
         current = current.__cause__ or current.__context__
 
     # If there is no message in the entire causal chain, fall back to the complete traceback.
-    return "\n" + traceback.format_exc().strip()
+    return traceback.format_exc().strip()

--- a/src/heretic/utils.py
+++ b/src/heretic/utils.py
@@ -7,6 +7,7 @@ import os
 import platform
 import random
 import tempfile
+import traceback
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from importlib.metadata import version
@@ -746,3 +747,27 @@ def upload_reproduce_folder(
                     repo_id=repo_id,
                     token=token,
                 )
+
+
+def format_exception(error: Exception) -> str:
+    message = str(error).strip()
+    if message:
+        return message
+
+    # Walk causal chain to find a non-empty message.
+    current = error
+    while current is not None:
+        msg = str(current).strip()
+        if msg:
+            return msg
+        current = current.__cause__ or current.__context__
+
+    # Fall back to type and traceback location info.
+    error_type = type(error).__name__
+    tb = error.__traceback__
+    if tb:
+        summary = traceback.extract_tb(tb)[-1]
+        filename = os.path.basename(summary.filename)
+        return f"{error_type} at {filename}:{summary.lineno}"
+
+    return error_type

--- a/src/heretic/utils.py
+++ b/src/heretic/utils.py
@@ -750,24 +750,13 @@ def upload_reproduce_folder(
 
 
 def format_exception(error: Exception) -> str:
-    message = str(error).strip()
-    if message:
-        return message
-
     # Walk causal chain to find a non-empty message.
     current = error
     while current is not None:
-        msg = str(current).strip()
-        if msg:
-            return msg
+        message = str(current).strip()
+        if message:
+            return message
         current = current.__cause__ or current.__context__
 
-    # Fall back to type and traceback location info.
-    error_type = type(error).__name__
-    tb = error.__traceback__
-    if tb:
-        summary = traceback.extract_tb(tb)[-1]
-        filename = os.path.basename(summary.filename)
-        return f"{error_type} at {filename}:{summary.lineno}"
-
-    return error_type
+    # If there is no message in the entire causal chain, fall back to the complete traceback.
+    return "\n" + traceback.format_exc().strip()


### PR DESCRIPTION
Falls back to printing the exception's class name in `main.py` and `model.py` if the exception's string representation is empty, preventing empty parentheses like `Failed ()` from being printed for exceptions without messages.

Closes #146.