### PR TITLE
fix: gracefully handle processor load failures for multimodal models (#82)

### DIFF
--- a/src/heretic/model.py
+++ b/src/heretic/model.py
@@ -88,7 +88,7 @@ class Model:
                     trust_remote_code=settings.trust_remote_code,
                     **self.revision_kwargs,
                 )
-            except Exception as error:
+            except (ImportError, OSError, ValueError, KeyError) as error:
                 print(
                     f"* [yellow]Warning[/]: Could not load processor ({error}). "
                     f"Multimodal saving/pushing may be incomplete."

--- a/src/heretic/model.py
+++ b/src/heretic/model.py
@@ -82,11 +82,17 @@ class Model:
         # Multimodal models have a processor we'll want to save.
         self.processor = None
         if get_model_class(settings.model) == AutoModelForImageTextToText:
-            self.processor = AutoProcessor.from_pretrained(
-                settings.model,
-                trust_remote_code=settings.trust_remote_code,
-                **self.revision_kwargs,
-            )
+            try:
+                self.processor = AutoProcessor.from_pretrained(
+                    settings.model,
+                    trust_remote_code=settings.trust_remote_code,
+                    **self.revision_kwargs,
+                )
+            except Exception as error:
+                print(
+                    f"* [yellow]Warning[/]: Could not load processor ({error}). "
+                    f"Multimodal saving/pushing may be incomplete."
+                )
 
         # Fallback for tokenizers that don't declare a special pad token.
         if self.tokenizer.pad_token is None:


### PR DESCRIPTION
Catches configuration/dependency load failures when initializing a multimodal model's processor, logging a warning rather than crashing the model initialization loop. This allows multimodal models to be abliterated on text-only pipelines even if optional vision dependencies (such as torchvision) are missing.