### PR TITLE
fix: preserve Hugging Face token in session to avoid repeated prompt (#142)

### DIFF
--- a/src/heretic/main.py
+++ b/src/heretic/main.py
@@ -856,7 +856,9 @@ def run():
                                         break
 
                                     if choice == "Switch account":
-                                        token = prompt_password("Hugging Face access token:")
+                                        token = prompt_password(
+                                            "Hugging Face access token:"
+                                        )
                                         if not token:
                                             break
                                         continue
@@ -865,7 +867,9 @@ def run():
                                     huggingface_token = token
                                 except Exception as e:
                                     print(f"[bold red]Authentication failed:[/] {e}")
-                                    token = prompt_password("Please enter a valid Hugging Face access token:")
+                                    token = prompt_password(
+                                        "Please enter a valid Hugging Face access token:"
+                                    )
                                     if not token:
                                         break
 

--- a/src/heretic/main.py
+++ b/src/heretic/main.py
@@ -831,17 +831,46 @@ def run():
                             token = huggingface_token or huggingface_hub.get_token()
                             if not token:
                                 token = prompt_password("Hugging Face access token:")
-                            if not token:
-                                continue
+                                if not token:
+                                    continue
 
-                            huggingface_token = None
-                            user = huggingface_hub.whoami(token)
-                            fullname = user.get(
-                                "fullname",
-                                user.get("name", "unknown user"),
-                            )
-                            email = user.get("email", "no email found")
-                            print(f"Logged in as [bold]{fullname} ({email})[/]")
+                            authenticated = False
+                            while not authenticated:
+                                try:
+                                    user = huggingface_hub.whoami(token)
+                                    fullname = user.get(
+                                        "fullname",
+                                        user.get("name", "unknown user"),
+                                    )
+                                    email = user.get("email", "no email found")
+                                    print(f"Logged in as [bold]{fullname} ({email})[/]")
+
+                                    choice = prompt_select(
+                                        "Do you want to proceed with this account or switch?",
+                                        [
+                                            "Proceed",
+                                            "Switch account",
+                                        ],
+                                    )
+                                    if choice is None:
+                                        break
+
+                                    if choice == "Switch account":
+                                        token = prompt_password("Hugging Face access token:")
+                                        if not token:
+                                            break
+                                        continue
+
+                                    authenticated = True
+                                    huggingface_token = token
+                                except Exception as e:
+                                    print(f"[bold red]Authentication failed:[/] {e}")
+                                    token = prompt_password("Please enter a valid Hugging Face access token:")
+                                    if not token:
+                                        break
+
+                            if not authenticated:
+                                continue
 
                             repo_id = prompt_text(
                                 "Name of repository:",

--- a/src/heretic/main.py
+++ b/src/heretic/main.py
@@ -834,8 +834,8 @@ def run():
                             if not token:
                                 continue
 
+                            huggingface_token = None
                             user = huggingface_hub.whoami(token)
-                            huggingface_token = token
                             fullname = user.get(
                                 "fullname",
                                 user.get("name", "unknown user"),
@@ -989,6 +989,7 @@ def run():
                                 )
 
                             print(f"Model uploaded to [bold]{repo_id}[/].")
+                            huggingface_token = token
 
                         case "Chat with the model":
                             print()

--- a/src/heretic/main.py
+++ b/src/heretic/main.py
@@ -639,6 +639,8 @@ def run():
     if len(study.trials) == settings.n_trials:
         study.set_user_attr("finished", True)
 
+    huggingface_token: str | None = None
+
     while True:
         # If no trials at all have been evaluated, the study must have been stopped
         # by pressing Ctrl+C while the first trial was running. In this case, we just
@@ -826,13 +828,14 @@ def run():
                             # We don't use huggingface_hub.login() because that stores the token on disk,
                             # and since this program will often be run on rented or shared GPU servers,
                             # it's better to not persist credentials.
-                            token = huggingface_hub.get_token()
+                            token = huggingface_token or huggingface_hub.get_token()
                             if not token:
                                 token = prompt_password("Hugging Face access token:")
                             if not token:
                                 continue
 
                             user = huggingface_hub.whoami(token)
+                            huggingface_token = token
                             fullname = user.get(
                                 "fullname",
                                 user.get("name", "unknown user"),


### PR DESCRIPTION
Currently, when using the interactive menu to save/upload model trials, users are prompted to enter their Hugging Face access token for every single upload attempt. This becomes repetitive if uploading multiple trials, pushing both the adapter and merged model, or retrying after a failed upload.

This PR introduces a session-level token cache that persists the credentials only for the duration of the CLI session. To keep it secure and avoid saving bad inputs, the token is cached only after it is successfully validated byhuggingface_hub.whoami(). Subsequent uploads in the same run reuse the cached token without persisting it to disk.