### PR TITLE
fix: reject bnb_4bit quantization when ARA is enabled

### DIFF
--- a/src/heretic/main.py
+++ b/src/heretic/main.py
@@ -186,6 +186,19 @@ def run():
         )
         return
 
+    if settings.use_ara and settings.quantization == QuantizationMethod.BNB_4BIT:
+        # ARA optimizes weight matrices in place, which requires trainable
+        # floating-point weights. bitsandbytes stores weights as packed
+        # integer tensors, so the optimization would fail partway through.
+        print(
+            '[red]ARA does not support bitsandbytes quantization ([bold]quantization = "bnb_4bit"[/]).[/]'
+        )
+        print(
+            "Either load the model without quantization, or set [bold]use_ara = false[/] "
+            "to use traditional directional ablation, which supports quantized models."
+        )
+        return
+
     # Adapted from https://github.com/huggingface/accelerate/blob/main/src/accelerate/commands/env.py
     if torch.cuda.is_available():
         count = torch.cuda.device_count()


### PR DESCRIPTION
## Problem

Running the `ara` branch with `quantization = "bnb_4bit"` crashes partway through abliteration:

```
RuntimeError: linalg.vector_norm: Expected a floating point or complex tensor as input. Got Byte
```

`ara_abliterate` runs LBFGS directly on `module.weight` and copies the result back in place. With bitsandbytes 4-bit quantization that weight is a packed `Params4bit` uint8 tensor, which can neither be normed nor used as a trainable parameter. The LoRA-based `abliterate` path handles dequantization before reading the weights, but the same is not possible for ARA's in-place optimization without a dequantize/requantize round trip, which is a larger design decision.

## Fix

Fail fast at startup with a clear error when `use_ara` and `bnb_4bit` are combined, instead of crashing mid-run after model loading. The message points users at `use_ara = false` (traditional directional ablation), which does support quantized models.

This does not add bnb support to ARA; it just turns an obscure crash into an actionable error until a decision is made on whether to support it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)