### PR TITLE
fix: force Qwen2TokenizerFast for qwen2 model types

### DIFF
--- a/src/heretic/model.py
+++ b/src/heretic/model.py
@@ -73,11 +73,32 @@ class Model:
         print()
         print(f"Loading model [bold]{settings.model}[/]...")
 
-        self.tokenizer = AutoTokenizer.from_pretrained(
+        # Load configuration dictionary to verify model type.
+        # This prevents tokenizers configured with incorrect classes in upstream
+        # config metadata from generating corrupted/space-stripped tokens.
+        config_dict, _ = PretrainedConfig.get_config_dict(
             settings.model,
             trust_remote_code=settings.trust_remote_code,
             **self.revision_kwargs,
         )
+
+        tokenizer_kwargs = {
+            "trust_remote_code": settings.trust_remote_code,
+            **self.revision_kwargs,
+        }
+
+        if config_dict.get("model_type") == "qwen2":
+            from transformers import Qwen2TokenizerFast  # ty:ignore[unresolved-import]
+
+            self.tokenizer = Qwen2TokenizerFast.from_pretrained(
+                settings.model,
+                **tokenizer_kwargs,
+            )
+        else:
+            self.tokenizer = AutoTokenizer.from_pretrained(
+                settings.model,
+                **tokenizer_kwargs,
+            )
 
         # Multimodal models have a processor we'll want to save.
         self.processor = None


### PR DESCRIPTION
This PR fixes a bug where Qwen2-based models (specifically distilled models like `deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B`) output byte-fallback characters (`Ġ`, `Ċ`) and miss spacing when using the CLI chat or evaluation loop.

Some upstream model repositories specify `LlamaTokenizerFast` as the `tokenizer_class` in their `tokenizer_config.json` configuration. When loaded via `AutoTokenizer`, this causes Hugging Face to apply Llama-style token decoding boundaries on Qwen's tiktoken BPE structure, leading to broken character offsets and missing spaces.

- Intercept tokenizer loading by reading the model's configuration dictionary.
- If `model_type` is `"qwen2"`, force the loader to initialize `Qwen2TokenizerFast` directly.
- Standard models continue to fall back to `AutoTokenizer` unmodified.