### PR TITLE
fix: save_pretrained unbound local active_adapters crash(#289)

### DIFF
--- a/src/heretic/model.py
+++ b/src/heretic/model.py
@@ -297,11 +297,13 @@ class Model:
             # Merge and unload
             print("* Merging LoRA adapters into base model...")
             merged_model = peft_model.merge_and_unload()
+            merged_model._hf_peft_config_loaded = False
             return merged_model
         else:
             # Non-quantized model - can merge directly
             print("* Merging LoRA adapters into base model...")
             merged_model = self.model.merge_and_unload()
+            merged_model._hf_peft_config_loaded = False
             # merge_and_unload() modifies self.model in-place, destroying LoRA adapters.
             # Mark for full reload if user switches trials later.
             self.needs_reload = True


### PR DESCRIPTION
After merging adapters, the base model retains an internal `_hf_peft_config_loaded` flag. When you call `save_pretrained()`, `transformers` tries to find active adapters that are no longer there, causing an `UnboundLocalError` crash.
Setting `_hf_peft_config_loaded = False` on the merged model immediately after the merge prevents the crash and allows the model to save normally.