### PR TITLE
fix: resolve requests/urllib3 dependency warning on startup(#373)

### DIFF
--- a/src/heretic/main.py
+++ b/src/heretic/main.py
@@ -4,6 +4,14 @@
 # ruff: noqa: E402
 
 import sys
+import warnings
+
+# Silence harmless transitive startup warning from requests about chardet/urllib3 compatibility.
+warnings.filterwarnings(
+    "ignore",
+    message=".*(chardet|charset_normalizer|urllib3).*doesn't match a supported version",
+    category=UserWarning,
+)
 
 from .config import Settings
 


### PR DESCRIPTION
Silences the urllib3/requests version mismatch warning on startup