### PR TITLE
fix: correct target trial math when running additional trials (#379)

### DIFF
--- a/src/heretic/main.py
+++ b/src/heretic/main.py
@@ -802,14 +802,14 @@ def run():
                     if n_additional_trials == 0:
                         continue
 
-                    settings.n_trials += n_additional_trials
+                    settings.n_trials = len(study.trials) + n_additional_trials
                     study.set_user_attr("settings", settings.model_dump_json())
                     study.set_user_attr("finished", False)
 
                     try:
                         study.optimize(
                             objective_wrapper,
-                            n_trials=settings.n_trials - len(study.trials),
+                            n_trials=n_additional_trials,
                         )
                     except KeyboardInterrupt:
                         pass


### PR DESCRIPTION
Hey, tracked down the bug with the "run additional trials" math! 

The old logic was accidentally adding the requested additional trials to the *original* target number, instead of the number of trials actually completed before cancelling. This caused `study.optimize` to queue up way too many ghost trials.

I just updated the math so the new target is correctly set to `len(study.trials) + n_additional_trials`, and it passes the exact requested number into the optimizer. Works perfectly now!