### PR TITLE
fix: correct total trial count when adding additional trials

### DIFF
--- a/src/heretic/main.py
+++ b/src/heretic/main.py
@@ -802,7 +802,7 @@ def run():
                     if n_additional_trials == 0:
                         continue
 
-                    settings.n_trials += n_additional_trials
+                    settings.n_trials = len(study.trials) + n_additional_trials
                     study.set_user_attr("settings", settings.model_dump_json())
                     study.set_user_attr("finished", False)
 


### PR DESCRIPTION
## Problem

When a study is cancelled mid-way and the user selects "Run additional trials", the displayed and actual trial count is wrong:

1. Start a study with 200 trials
2. Cancel after ~30 trials
3. Select "Run additional trials" and enter 10

**Actual (buggy):** "Running trial 31 of 210..." — 180 more trials planned  
**Expected:** "Running trial 31 of 40..." — 10 more trials planned

**Root cause:** `settings.n_trials += n_additional_trials` accumulates the original total into the new total. After the first cancel+add, `n_trials` becomes `200 + 10 = 210`. On a second cancel+add, it becomes `210 + 10 = 220`. The value only grows.

## Fix

One-line change: replace `settings.n_trials += n_additional_trials` with `settings.n_trials = len(study.trials) + n_additional_trials`.

This recalculates the total target from actual completed trials + additional, rather than growing the stale original target. After 30 completed + 10 additional, `n_trials = 40`, displaying "Running trial 31 of 40..." and planning exactly 10 more trials.

Fixes #379

🤖 Generated with [Claude Code](https://claude.com/claude-code)
