### PR TITLE
feat: let the optimizer disable MLP ablation via a 0 max_weight floor

### DIFF
--- a/src/heretic/main.py
+++ b/src/heretic/main.py
@@ -578,9 +578,16 @@ def run():
             # The parameter ranges are based on experiments with various models
             # and much wider ranges. They are not set in stone and might have to be
             # adjusted for future models.
+            #
+            # The MLP gets a lower bound of 0 so that the optimizer can effectively
+            # disable its ablation (max_weight 0 yields a zero adapter). Ablating the
+            # MLP is often unnecessary for removing refusals and tends to damage model
+            # intelligence more than ablating the attention output, so on many models
+            # the optimum is to leave it (mostly) untouched. See issue #202.
+            max_weight_lower_bound = 0.0 if component == "mlp.down_proj" else 0.8
             max_weight = trial.suggest_float(
                 f"{component}.max_weight",
-                0.8,
+                max_weight_lower_bound,
                 1.5,
             )
             max_weight_position = trial.suggest_float(

--- a/src/heretic/main.py
+++ b/src/heretic/main.py
@@ -579,16 +579,21 @@ def run():
             # and much wider ranges. They are not set in stone and might have to be
             # adjusted for future models.
             #
-            # The MLP gets a lower bound of 0 so that the optimizer can effectively
-            # disable its ablation (max_weight 0 yields a zero adapter). Ablating the
-            # MLP is often unnecessary for removing refusals and tends to damage model
-            # intelligence more than ablating the attention output, so on many models
-            # the optimum is to leave it (mostly) untouched. See issue #202.
-            max_weight_lower_bound = 0.0 if component == "mlp.down_proj" else 0.8
-            max_weight = trial.suggest_float(
-                f"{component}.max_weight",
-                max_weight_lower_bound,
-                1.5,
+            # The MLP gets a negative lower bound that is then clamped to 0, so the
+            # optimizer can fully disable its ablation. The clamp puts a positive
+            # probability mass on exactly 0 (the continuous sampler would otherwise
+            # reach 0 with probability zero). Ablating the MLP is often unnecessary for
+            # removing refusals and tends to damage model intelligence more than
+            # ablating the attention output, so on many models the optimum is to leave
+            # it (mostly) untouched. See issue #202.
+            max_weight_lower_bound = -0.25 if component == "mlp.down_proj" else 0.8
+            max_weight = max(
+                0.0,
+                trial.suggest_float(
+                    f"{component}.max_weight",
+                    max_weight_lower_bound,
+                    1.5,
+                ),
             )
             max_weight_position = trial.suggest_float(
                 f"{component}.max_weight_position",

--- a/src/heretic/model.py
+++ b/src/heretic/model.py
@@ -499,6 +499,12 @@ class Model:
                     params.min_weight - params.max_weight
                 )
 
+                # A weight of 0 disables this component's ablation. reset_model() has
+                # already left the adapter at identity, so abort before the otherwise
+                # wasteful decomposition (which would also be operating on a zero matrix).
+                if weight == 0:
+                    continue
+
                 if refusal_direction is None:
                     # The index must be shifted by 1 because the first element
                     # of refusal_directions is the direction for the embeddings.


### PR DESCRIPTION
Implements the MLP `max_weight` lower bound of 0 you proposed in #202, so the optimizer can disable MLP ablation per model instead of always applying at least 0.8x. Attention keeps its 0.8 floor.

Data and rationale: https://github.com/p-e-w/heretic/issues/202#issuecomment-4720075210 — across SmolLM3-3B (MLP unnecessary) and Qwen3-4B (MLP needed), 3 seeds each, the optimizer drives the MLP toward 0 where it's collateral damage and keeps it high where it lowers refusals, with no model-specific code. Since `[0.0, 1.5] ⊇ [0.8, 1.5]`, it can't reduce the achievable Pareto front.

Happy to express the floor however you prefer (inline conditional as here, a per-component constant, a setting, etc.).
