### PR TITLE
feat: generate model card on local save (#258)

### DIFF
--- a/src/heretic/main.py
+++ b/src/heretic/main.py
@@ -47,7 +47,7 @@ import questionary
 import torch
 import torch.nn.functional as F
 import transformers
-from huggingface_hub import HfApi, ModelCard, ModelCardData
+from huggingface_hub import HfApi
 from lm_eval.models.huggingface import HFLM
 from optuna import Trial, TrialPruned
 from optuna.exceptions import ExperimentalWarning
@@ -76,7 +76,6 @@ from .utils import (
     format_duration,
     format_exception,
     get_file_sha256,
-    get_readme_intro,
     get_trial_parameters,
     is_hf_path,
     load_prompts,

--- a/src/heretic/main.py
+++ b/src/heretic/main.py
@@ -72,6 +72,7 @@ from .reproduce import (
 )
 from .system import empty_cache, get_accelerator_info
 from .utils import (
+    create_model_card,
     format_duration,
     format_exception,
     get_file_sha256,
@@ -906,6 +907,17 @@ def run():
 
                             print(f"Model saved to [bold]{save_directory}[/].")
 
+                            card = create_model_card(
+                                settings,
+                                trial,
+                                contains_reproducibility_information=False,
+                            )
+                            if card is not None:
+                                card.save(
+                                    Path(save_directory)
+                                    / huggingface_hub.constants.REPOCARD_NAME
+                                )
+
                             if reproduction_mode and verify_hashes:
                                 print("Verifying hashes of weight files...")
 
@@ -1047,37 +1059,13 @@ def run():
                                     )
                                 reset_trial_model()
 
-                            if is_hf_path(settings.model):
-                                card = ModelCard.load(settings.model)
-                            else:
-                                card_path = (
-                                    Path(settings.model)
-                                    / huggingface_hub.constants.REPOCARD_NAME
-                                )
-                                if card_path.exists():
-                                    card = ModelCard.load(card_path)
-                                else:
-                                    card = None
-
+                            card = create_model_card(
+                                settings,
+                                trial,
+                                contains_reproducibility_information=reproducibility_information
+                                != "none",
+                            )
                             if card is not None:
-                                if card.data is None:
-                                    card.data = ModelCardData()
-                                if card.data.tags is None:
-                                    card.data.tags = []
-                                card.data.tags.append("heretic")
-                                card.data.tags.append("uncensored")
-                                card.data.tags.append("decensored")
-                                card.data.tags.append("abliterated")
-                                if reproducibility_information != "none":
-                                    card.data.tags.append("reproducible")
-                                card.text = (
-                                    get_readme_intro(
-                                        settings,
-                                        trial,
-                                        reproducibility_information != "none",
-                                    )
-                                    + card.text
-                                )
                                 card.push_to_hub(repo_id, token=token)
 
                             if reproducibility_information != "none":

--- a/src/heretic/utils.py
+++ b/src/heretic/utils.py
@@ -380,10 +380,7 @@ def create_model_card(
     if is_hf_path(settings.model):
         card = huggingface_hub.ModelCard.load(settings.model)
     else:
-        card_path = (
-            Path(settings.model)
-            / huggingface_hub.constants.REPOCARD_NAME
-        )
+        card_path = Path(settings.model) / huggingface_hub.constants.REPOCARD_NAME
         if card_path.exists():
             card = huggingface_hub.ModelCard.load(card_path)
         else:

--- a/src/heretic/utils.py
+++ b/src/heretic/utils.py
@@ -371,6 +371,47 @@ def get_readme_intro(
 """
 
 
+def create_model_card(
+    settings: Settings,
+    trial: Trial | FrozenTrial,
+    contains_reproducibility_information: bool = False,
+) -> huggingface_hub.ModelCard | None:
+    """Generates the abliterated model card by extending the base model's card."""
+    if is_hf_path(settings.model):
+        card = huggingface_hub.ModelCard.load(settings.model)
+    else:
+        card_path = (
+            Path(settings.model)
+            / huggingface_hub.constants.REPOCARD_NAME
+        )
+        if card_path.exists():
+            card = huggingface_hub.ModelCard.load(card_path)
+        else:
+            card = None
+
+    if card is not None:
+        if card.data is None:
+            card.data = huggingface_hub.ModelCardData()
+        if card.data.tags is None:
+            card.data.tags = []
+        card.data.tags.append("heretic")
+        card.data.tags.append("uncensored")
+        card.data.tags.append("decensored")
+        card.data.tags.append("abliterated")
+        if contains_reproducibility_information:
+            card.data.tags.append("reproducible")
+        card.text = (
+            get_readme_intro(
+                settings,
+                trial,
+                contains_reproducibility_information,
+            )
+            + card.text
+        )
+
+    return card
+
+
 def generate_config_toml(settings: Settings) -> str:
     """Serializes the full Settings object to TOML."""
 

--- a/src/heretic/utils.py
+++ b/src/heretic/utils.py
@@ -375,37 +375,44 @@ def create_model_card(
     settings: Settings,
     trial: Trial | FrozenTrial,
     contains_reproducibility_information: bool = False,
-) -> huggingface_hub.ModelCard | None:
+) -> huggingface_hub.ModelCard:
     """Generates the abliterated model card by extending the base model's card."""
+    card: huggingface_hub.ModelCard | None = None
     if is_hf_path(settings.model):
-        card = huggingface_hub.ModelCard.load(settings.model)
+        try:
+            card = huggingface_hub.ModelCard.load(settings.model)
+        except Exception:
+            # Fall back to an empty card if the base card cannot be loaded.
+            pass
     else:
         card_path = Path(settings.model) / huggingface_hub.constants.REPOCARD_NAME
         if card_path.exists():
-            card = huggingface_hub.ModelCard.load(card_path)
-        else:
-            card = None
+            try:
+                card = huggingface_hub.ModelCard.load(card_path)
+            except Exception:
+                # Fall back to an empty card if the base card cannot be loaded.
+                pass
 
-    if card is not None:
-        if card.data is None:
-            card.data = huggingface_hub.ModelCardData()
-        if card.data.tags is None:
-            card.data.tags = []
-        card.data.tags.append("heretic")
-        card.data.tags.append("uncensored")
-        card.data.tags.append("decensored")
-        card.data.tags.append("abliterated")
-        if contains_reproducibility_information:
-            card.data.tags.append("reproducible")
-        card.text = (
-            get_readme_intro(
-                settings,
-                trial,
-                contains_reproducibility_information,
-            )
-            + card.text
-        )
+    if card is None:
+        card = huggingface_hub.ModelCard("")
 
+    if card.data is None:
+        card.data = huggingface_hub.ModelCardData()
+    if getattr(card.data, "tags", None) is None:
+        card.data.tags = []  # type: ignore
+
+    tags: list[str] = card.data.tags  # type: ignore
+    tags.append("heretic")
+    tags.append("uncensored")
+    tags.append("decensored")
+    tags.append("abliterated")
+    if contains_reproducibility_information:
+        tags.append("reproducible")
+    card.text = get_readme_intro(
+        settings,
+        trial,
+        contains_reproducibility_information,
+    ) + (card.text or "")
     return card
 
 


### PR DESCRIPTION
I Noticed that if someone hits "Save to local folder", the model card/README gets entirely skipped and only the weights drop. 

To fix it without duplicating any code, I just pulled the `ModelCard` generation logic out of the HF upload block into a clean `create_model_card()` helper function over in `utils.py`. 
Now the local save routine just hits that exact same helper to automatically drop the `README.md` right next to the local weight files. Works perfectly and keeps the HF upload logic a lot cleaner too! Let me know if you need anything tweaked.