### PR TITLE
fix: resolve UnicodeEncodeError on Windows during model evaluation

### DIFF
--- a/src/heretic/main.py
+++ b/src/heretic/main.py
@@ -5,8 +5,13 @@
 
 import sys
 
-from .config import Settings
+# Ensure standard output/error use UTF-8 instead of system default charmap (e.g. cp1252 on Windows)
+if hasattr(sys.stdout, "reconfigure") and getattr(sys.stdout, "encoding", "").lower() != "utf-8":
+    sys.stdout.reconfigure(encoding="utf-8")  # type: ignore
+if hasattr(sys.stderr, "reconfigure") and getattr(sys.stderr, "encoding", "").lower() != "utf-8":
+    sys.stderr.reconfigure(encoding="utf-8")  # type: ignore
 
+from .config import Settings
 
 def _is_help_invocation() -> bool:
     args = sys.argv[1:]

--- a/src/heretic/main.py
+++ b/src/heretic/main.py
@@ -5,13 +5,20 @@
 
 import sys
 
-# Ensure standard output/error use UTF-8 instead of system default charmap (e.g. cp1252 on Windows)
-if hasattr(sys.stdout, "reconfigure") and getattr(sys.stdout, "encoding", "").lower() != "utf-8":
+# Ensure standard output/error use UTF-8 instead of system default charmap (e.g. cp1252 on Windows).
+if (
+    hasattr(sys.stdout, "reconfigure")
+    and (getattr(sys.stdout, "encoding", "") or "").lower() != "utf-8"
+):
     sys.stdout.reconfigure(encoding="utf-8")  # type: ignore
-if hasattr(sys.stderr, "reconfigure") and getattr(sys.stderr, "encoding", "").lower() != "utf-8":
+if (
+    hasattr(sys.stderr, "reconfigure")
+    and (getattr(sys.stderr, "encoding", "") or "").lower() != "utf-8"
+):
     sys.stderr.reconfigure(encoding="utf-8")  # type: ignore
 
 from .config import Settings
+
 
 def _is_help_invocation() -> bool:
     args = sys.argv[1:]

--- a/src/heretic/main.py
+++ b/src/heretic/main.py
@@ -6,16 +6,12 @@
 import sys
 
 # Ensure standard output/error use UTF-8 instead of system default charmap (e.g. cp1252 on Windows).
-if (
-    hasattr(sys.stdout, "reconfigure")
-    and (getattr(sys.stdout, "encoding", "") or "").lower() != "utf-8"
-):
-    sys.stdout.reconfigure(encoding="utf-8")  # type: ignore
-if (
-    hasattr(sys.stderr, "reconfigure")
-    and (getattr(sys.stderr, "encoding", "") or "").lower() != "utf-8"
-):
-    sys.stderr.reconfigure(encoding="utf-8")  # type: ignore
+for stream in (sys.stdout, sys.stderr):
+    if (
+        hasattr(stream, "reconfigure")
+        and (getattr(stream, "encoding", "") or "").lower() != "utf-8"
+    ):
+        stream.reconfigure(encoding="utf-8")  # type: ignore
 
 from .config import Settings
 


### PR DESCRIPTION
Forces `sys.stdout` and `sys.stderr` to use UTF-8 encoding on Windows. This prevents `UnicodeEncodeError` crashes ("charmap codec can't encode characters") when external libraries like `transformers` or the standard `logging` module emit warnings containing special Unicode characters. 
By fixing the crash during the model warmup phase, this also prevents the subsequent infinite hangs caused by the batch size calculator falling into a broken state.