### PR TITLE
feat: add support for Qwen3Next shared experts

### DIFF
--- a/src/heretic/model.py
+++ b/src/heretic/model.py
@@ -401,6 +401,9 @@ class Model:
             for expert in layer.mlp.experts:  # ty:ignore[possibly-missing-attribute, not-iterable]
                 try_add("mlp.down_proj", expert.down_proj)  # ty:ignore[possibly-missing-attribute]
 
+        with suppress(Exception):
+            try_add("mlp.down_proj", layer.mlp.shared_expert.down_proj)  # ty:ignore[possibly-missing-attribute]
+
         # Phi-3.5-MoE (and possibly others).
         with suppress(Exception):
             for expert in layer.block_sparse_moe.experts:  # ty:ignore[possibly-missing-attribute, not-iterable]


### PR DESCRIPTION
Adds `layer.mlp.shared_expert.down_proj` to the abliteration targets. 

This ensures that the shared expert in Qwen3-Next MoE models (which handles a significant portion of general knowledge) is properly abliterated. 

The `AttributeError` on `self_attn` reported in the issue is already mitigated by the `suppress(Exception)` blocks added previously to `master`.