### PR TITLE
narrow batch-size benchmark except to (RuntimeError, ValueError, TypeError, OSError)

### DIFF
--- a/src/heretic/main.py
+++ b/src/heretic/main.py
@@ -415,7 +415,7 @@ def run():
                 start_time = time.perf_counter()
                 responses = model.get_responses(prompts)
                 end_time = time.perf_counter()
-            except Exception as error:
+            except (RuntimeError, ValueError, TypeError, OSError) as error:
                 if batch_size == 1:
                     # Even a batch size of 1 already fails.
                     # We cannot recover from this.

--- a/src/heretic/model.py
+++ b/src/heretic/model.py
@@ -148,7 +148,7 @@ class Model:
                     ],
                     max_new_tokens=1,
                 )
-            except Exception as error:
+            except (RuntimeError, ValueError, TypeError) as error:
                 self.model = None  # ty:ignore[invalid-assignment]
                 empty_cache()
 


### PR DESCRIPTION
model.get_responses() walks the same generate() path that's already guarded by the narrower `except (RuntimeError, ValueError, TypeError)` clause in model.py:137 — CUDA OOM, dtype mismatches, bad config, and type errors are exactly what surfaces from self.model.generate(), not arbitrary Exception. Catching all Exception here also masked KeyboardInterrupt-style failures (the existing test loop relies on the benchmark break-out path).