### PR TITLE
Support fused-expert MoE architectures (Qwen3.5-MoE)

### DIFF
--- a/src/heretic/model.py
+++ b/src/heretic/model.py
@@ -62,6 +62,8 @@ class Model:
     processor: ProcessorMixin | None
     peft_config: LoraConfig
     dtype: torch.dtype
+    # Original weights of fused-expert MoE tensors, cached to keep abliteration reversible.
+    _fused_experts_cache: dict[int, tuple[torch.nn.Parameter, Tensor]]
 
     def __init__(self, settings: Settings):
         self.settings = settings
@@ -628,8 +630,11 @@ class Model:
         )
 
     def _abliterate_fused_experts(
-        self, refusal_directions, refusal_direction, parameters
-    ):
+        self,
+        refusal_directions: Tensor,
+        refusal_direction: Tensor | None,
+        parameters: dict[str, AbliterationParameters],
+    ) -> None:
         """Orthogonalize fused-expert MoE blocks.
 
         Some MoE implementations (e.g. transformers' ``Qwen3_5MoeExperts``) pack all experts
@@ -652,8 +657,22 @@ class Model:
         except Exception:
             hidden = getattr(self.model.config, "hidden_size", None)
         for layer_index, layer in enumerate(self.get_layers()):
-            experts = getattr(getattr(layer, "mlp", None), "experts", None)
-            fused = getattr(experts, "down_proj", None)
+            # Locate the experts container across the architectures Heretic supports.
+            experts = None
+            for block_name in ("mlp", "block_sparse_moe", "feed_forward", "moe"):
+                block = getattr(layer, block_name, None)
+                if block is not None:
+                    experts = getattr(block, "experts", None)
+                    if experts is not None:
+                        break
+            if experts is None:
+                continue
+            # The fused down-projection may be named differently across families.
+            fused = None
+            for param_name in ("down_proj", "w2", "output_linear"):
+                fused = getattr(experts, param_name, None)
+                if fused is not None:
+                    break
             if not isinstance(fused, torch.nn.Parameter) or fused.dim() != 3:
                 continue
             # Expect [num_experts, out=hidden, in=inter]; skip on unexpected orientation.
@@ -678,11 +697,12 @@ class Model:
             else:
                 v = refusal_direction
             v = F.normalize(v.to(torch.float32).to(fused.device), dim=0)
-            original_f = original.to(torch.float32).to(fused.device)
-            # proj[e, in] = v^T W_e, contracting over the hidden (out) dimension.
-            proj = torch.einsum("h,ehi->ei", v, original_f)
+            # The cached original was cloned from the parameter, so it is already on device.
+            original_fp32 = original.to(torch.float32)
+            # Projection has shape [num_experts, inter]: v^T W_e, contracting the hidden dim.
+            proj = torch.einsum("h,ehi->ei", v, original_fp32)
             delta = weight * v.view(1, -1, 1) * proj.unsqueeze(1)
-            fused.data.copy_((original_f - delta).to(fused.dtype))
+            fused.data.copy_((original_fp32 - delta).to(fused.dtype))
 
     def generate(
         self,

--- a/src/heretic/model.py
+++ b/src/heretic/model.py
@@ -66,6 +66,7 @@ class Model:
     def __init__(self, settings: Settings):
         self.settings = settings
         self.needs_reload = False
+        self._fused_experts_cache = {}
 
         self.revision_kwargs = {}
         if settings.model_commit is not None:
@@ -333,10 +334,13 @@ class Model:
             for name, module in self.model.named_modules():
                 if "lora_B" in name and hasattr(module, "weight"):
                     torch.nn.init.zeros_(module.weight)
+            for fused, original in self._fused_experts_cache.values():
+                fused.data.copy_(original)
             return
 
         # Purge existing model object from memory to make space.
         self.model = None  # ty:ignore[invalid-assignment]
+        self._fused_experts_cache = {}
         empty_cache()
 
         quantization_config = self._get_quantization_config(
@@ -617,6 +621,68 @@ class Model:
                     weight_B = cast(Tensor, module.lora_B["default"].weight)
                     weight_A.data = lora_A.to(weight_A.dtype)
                     weight_B.data = lora_B.to(weight_B.dtype)
+
+        # Fused-expert MoE blocks (e.g. Qwen3.5-MoE) are not reached by the loop above.
+        self._abliterate_fused_experts(
+            refusal_directions, refusal_direction, parameters
+        )
+
+    def _abliterate_fused_experts(
+        self, refusal_directions, refusal_direction, parameters
+    ):
+        """Orthogonalize fused-expert MoE blocks.
+
+        Some MoE implementations (e.g. transformers' ``Qwen3_5MoeExperts``) pack all experts
+        into batched tensors instead of a ``ModuleList`` of Linear experts, so
+        ``get_layer_modules()`` (which does ``for expert in layer.mlp.experts``) never reaches
+        them and every routed expert is silently skipped. Since most of a MoE's refusal
+        behaviour lives in the routed experts, abliteration then plateaus far above zero.
+
+        Here the batched ``experts.down_proj`` of shape ``[num_experts, hidden, inter]`` is
+        orthogonalized per expert against the same per-layer refusal direction and weight
+        schedule as the dense path. The base tensor is edited directly (reversibly, via a
+        cached original), so no LoRA adapter is involved and ``get_merged_model()`` needs no
+        change.
+        """
+        if "mlp.down_proj" not in parameters:
+            return
+        params = parameters["mlp.down_proj"]
+        try:
+            hidden = self.model.config.get_text_config().hidden_size
+        except Exception:
+            hidden = getattr(self.model.config, "hidden_size", None)
+        for layer_index, layer in enumerate(self.get_layers()):
+            experts = getattr(getattr(layer, "mlp", None), "experts", None)
+            fused = getattr(experts, "down_proj", None)
+            if not isinstance(fused, torch.nn.Parameter) or fused.dim() != 3:
+                continue
+            # Expect [num_experts, out=hidden, in=inter]; skip on unexpected orientation.
+            if hidden is not None and fused.shape[1] != hidden:
+                continue
+            cache = self._fused_experts_cache
+            if id(fused) not in cache:
+                cache[id(fused)] = (fused, fused.data.clone())
+            _, original = cache[id(fused)]
+            # Restore the original before (re-)abliterating, so trials are independent.
+            fused.data.copy_(original)
+            distance = abs(layer_index - params.max_weight_position)
+            if distance > params.min_weight_distance:
+                continue
+            weight = params.max_weight + (distance / params.min_weight_distance) * (
+                params.min_weight - params.max_weight
+            )
+            if weight == 0:
+                continue
+            if refusal_direction is None:
+                v = refusal_directions[layer_index + 1]
+            else:
+                v = refusal_direction
+            v = F.normalize(v.to(torch.float32).to(fused.device), dim=0)
+            original_f = original.to(torch.float32).to(fused.device)
+            # proj[e, in] = v^T W_e, contracting over the hidden (out) dimension.
+            proj = torch.einsum("h,ehi->ei", v, original_f)
+            delta = weight * v.view(1, -1, 1) * proj.unsqueeze(1)
+            fused.data.copy_((original_f - delta).to(fused.dtype))
 
     def generate(
         self,


### PR DESCRIPTION
## The problem

`Model.get_layer_modules()` discovers per-layer residual-writing modules by iterating experts:

```python
with suppress(Exception):
    for expert in layer.mlp.experts:            # assumes an iterable of Linear experts
        try_add("mlp.down_proj", expert.down_proj)
```

This assumes each expert is a `Module` with a `.down_proj` `nn.Linear`. Several modern MoE
implementations instead **fuse all experts into batched tensors**. In transformers'
`Qwen3_5MoeExperts` (Qwen3.5-MoE) the block is:

```
Qwen3_5MoeSparseMoeBlock(gate, experts=Qwen3_5MoeExperts, shared_expert, shared_expert_gate)
Qwen3_5MoeExperts:
    gate_up_proj : Parameter [num_experts, 2*inter, hidden]
    down_proj    : Parameter [num_experts, hidden, inter]   # what writes to the residual
    # forward: nn.functional.linear(x, self.down_proj[expert_idx])
```

`for expert in layer.mlp.experts` yields nothing usable (it is not a `ModuleList`), so the
`suppress(Exception)` swallows it and **every routed expert is silently skipped**. Only
`attn.o_proj` and the shared-expert `down_proj` get abliterated. Because most of a MoE's refusal
behaviour lives in the routed experts, the optimizer cannot lower refusals no matter how many
trials it runs.

### Observed impact (a 256-expert, 40-layer Qwen3.5-MoE)
- Current Heretic: baseline 99/100, **best over 200 trials = 88/100** (nothing dips below 88).
- Orthogonalizing the fused `experts.down_proj` too (this PR), same directions and math: refusals
  drop to **0** on a held-out harmful set. The 88 floor was entirely the untouched experts
  (10240 expert output slices, 256 x 40, left bf16-identical).

## The fix

For a fused `down_proj` of shape `[E, hidden, inter]` and unit direction `v` in hidden space,
apply the projection removal Heretic already uses, `W_e <- W_e - weight * v (v^T W_e)`, vectorized
over experts:

```python
proj  = torch.einsum("h,ehi->ei", v, down_proj)        # [E, inter]
delta = weight * v.view(1, -1, 1) * proj.unsqueeze(1)   # [E, hidden, inter]
down_proj -= delta
```

Same per-layer direction and `max_weight`/`min_weight` schedule as the dense path.
`gate_up_proj` writes to the intermediate space (not the residual) and is left untouched, matching
the existing `up_proj`/`gate_proj` policy.

### Details
- The fused tensor is a `Parameter`, not an `nn.Linear`, so it cannot be LoRA-wrapped. It is edited
  **directly and reversibly**: the original is cached once and restored before each trial, so trials
  stay independent. `get_merged_model()` is unchanged because the edit is on the base weights.
- `reset_model()` restores the cached originals on the fast path and invalidates the cache on full
  reload (the params are recreated).
- Detection is conservative: only a 3-D `experts.down_proj` `Parameter` whose `shape[1] == hidden`
  is treated as fused. Iterable-expert MoEs (Mixtral, Phi-3.5-MoE) go through the existing path
  unchanged.

## Validation

End-to-end validation was done with an equivalent standalone implementation (per-layer directions,
the same fused orthogonalization) because a full Heretic run on the 35B needs a lot of memory; it
reproduced the 99 -> 0 result above. The integrated version in this PR applies the same math inside
`abliterate()` and reuses the existing direction/weight machinery. The repo already ships a
`tests/qwen3.5-moe` case, whose expected hashes will need regenerating since abliteration now
(correctly) touches the experts.

Happy to adjust naming/structure or add a unit test for the fused branch if you'd like.
