### PR TITLE
fix: validate scorer instance names in config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,6 @@ jobs:
   checks:
     name: Check and build (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
-    env:
-      UV_PYTHON: ${{ matrix.python-version }}
     strategy:
       fail-fast: false
       matrix:
@@ -46,7 +44,7 @@ jobs:
         env:
           PYTHONUNBUFFERED: "1"
         run: |
-          uv run python -m unittest discover -s tests -p "test_*.py"
+          uv run python -m unittest discover -s tests -p 'test_*.py'
           uv run tests/run_tests.py 2>&1
 
       - name: Build package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ jobs:
   checks:
     name: Check and build (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    env:
+      UV_PYTHON: ${{ matrix.python-version }}
     strategy:
       fail-fast: false
       matrix:
@@ -43,7 +45,9 @@ jobs:
       - name: Run tests
         env:
           PYTHONUNBUFFERED: "1"
-        run: uv run tests/run_tests.py 2>&1
+        run: |
+          uv run python -m unittest discover -s tests -p "test_*.py"
+          uv run tests/run_tests.py 2>&1
 
       - name: Build package
         run: uv build

--- a/src/heretic/config.py
+++ b/src/heretic/config.py
@@ -133,8 +133,11 @@ class ScorerConfig(BaseModel):
         if not value.strip():
             raise ValueError("cannot be empty or whitespace")
 
-        if "." in value or any(char.isspace() for char in value):
-            raise ValueError("'.' and whitespace are not allowed")
+        if "." in value:
+            raise ValueError("'.' is not allowed")
+
+        if any(char.isspace() for char in value):
+            raise ValueError("whitespace is not allowed")
 
         return value
 

--- a/src/heretic/config.py
+++ b/src/heretic/config.py
@@ -9,6 +9,7 @@ from pydantic import (
     Field,
     NonNegativeInt,
     PositiveInt,
+    field_validator,
 )
 from pydantic_settings import (
     BaseSettings,
@@ -122,6 +123,20 @@ class ScorerConfig(BaseModel):
             "Instance-specific settings live under `[scorer.<ClassName>_<instance_name>]`."
         ),
     )
+
+    @field_validator("instance_name")
+    @classmethod
+    def validate_instance_name(cls, value: str | None) -> str | None:
+        if value is None:
+            return value
+
+        if not value.strip():
+            raise ValueError("cannot be empty or whitespace")
+
+        if "." in value or any(char.isspace() for char in value):
+            raise ValueError("'.' and whitespace are not allowed")
+
+        return value
 
 
 class BenchmarkSpecification(BaseModel):

--- a/src/heretic/evaluator.py
+++ b/src/heretic/evaluator.py
@@ -67,18 +67,6 @@ class Evaluator:
             # Instantiate scorers.
             instance_name = config.instance_name or None
 
-            if instance_name is not None:
-                if not instance_name.strip():
-                    raise ValueError(
-                        f"Invalid instance_name {instance_name} for scorer {scorer_cls.__name__}: "
-                        "cannot be empty or whitespace"
-                    )
-                if "." in instance_name or " " in instance_name:
-                    raise ValueError(
-                        f"Invalid instance_name {instance_name} for scorer {scorer_cls.__name__}: "
-                        "'.' and whitespace are not allowed"
-                    )
-
             raw_settings = self._get_scorer_settings_raw(
                 scorer_cls=scorer_cls, instance_name=instance_name
             )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2025-2026  Philipp Emanuel Weidmann <pew@worldwidemann.com> + contributors
+
+import unittest
+
+from pydantic import ValidationError
+
+from heretic.config import ScorerConfig
+
+
+class ScorerConfigTests(unittest.TestCase):
+    def test_accepts_slug_like_instance_name(self):
+        config = ScorerConfig(
+            plugin="heretic.scorers.keyword_rate.KeywordRate",
+            optimization="minimize",
+            instance_name="small-1",
+        )
+
+        self.assertEqual(config.instance_name, "small-1")
+
+    def test_rejects_empty_instance_name(self):
+        with self.assertRaises(ValidationError):
+            ScorerConfig(
+                plugin="heretic.scorers.keyword_rate.KeywordRate",
+                optimization="minimize",
+                instance_name=" \t",
+            )
+
+    def test_rejects_whitespace_in_instance_name(self):
+        for instance_name in ["small name", "small\tname", "small\nname"]:
+            with self.subTest(instance_name=instance_name):
+                with self.assertRaises(ValidationError):
+                    ScorerConfig(
+                        plugin="heretic.scorers.keyword_rate.KeywordRate",
+                        optimization="minimize",
+                        instance_name=instance_name,
+                    )
+
+    def test_rejects_dot_in_instance_name(self):
+        with self.assertRaises(ValidationError):
+            ScorerConfig(
+                plugin="heretic.scorers.keyword_rate.KeywordRate",
+                optimization="minimize",
+                instance_name="small.name",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -29,7 +29,9 @@ class ScorerConfigTests(unittest.TestCase):
     def test_rejects_whitespace_in_instance_name(self) -> None:
         for instance_name in ["small name", "small\tname", "small\nname"]:
             with self.subTest(instance_name=instance_name):
-                with self.assertRaises(ValidationError):
+                with self.assertRaisesRegex(
+                    ValidationError, "whitespace is not allowed"
+                ):
                     ScorerConfig(
                         plugin="heretic.scorers.keyword_rate.KeywordRate",
                         optimization="minimize",
@@ -37,7 +39,7 @@ class ScorerConfigTests(unittest.TestCase):
                     )
 
     def test_rejects_dot_in_instance_name(self) -> None:
-        with self.assertRaises(ValidationError):
+        with self.assertRaisesRegex(ValidationError, "'\\.' is not allowed"):
             ScorerConfig(
                 plugin="heretic.scorers.keyword_rate.KeywordRate",
                 optimization="minimize",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,7 +9,7 @@ from heretic.config import ScorerConfig
 
 
 class ScorerConfigTests(unittest.TestCase):
-    def test_accepts_slug_like_instance_name(self):
+    def test_accepts_slug_like_instance_name(self) -> None:
         config = ScorerConfig(
             plugin="heretic.scorers.keyword_rate.KeywordRate",
             optimization="minimize",
@@ -18,7 +18,7 @@ class ScorerConfigTests(unittest.TestCase):
 
         self.assertEqual(config.instance_name, "small-1")
 
-    def test_rejects_empty_instance_name(self):
+    def test_rejects_empty_instance_name(self) -> None:
         with self.assertRaises(ValidationError):
             ScorerConfig(
                 plugin="heretic.scorers.keyword_rate.KeywordRate",
@@ -26,7 +26,7 @@ class ScorerConfigTests(unittest.TestCase):
                 instance_name=" \t",
             )
 
-    def test_rejects_whitespace_in_instance_name(self):
+    def test_rejects_whitespace_in_instance_name(self) -> None:
         for instance_name in ["small name", "small\tname", "small\nname"]:
             with self.subTest(instance_name=instance_name):
                 with self.assertRaises(ValidationError):
@@ -36,7 +36,7 @@ class ScorerConfigTests(unittest.TestCase):
                         instance_name=instance_name,
                     )
 
-    def test_rejects_dot_in_instance_name(self):
+    def test_rejects_dot_in_instance_name(self) -> None:
         with self.assertRaises(ValidationError):
             ScorerConfig(
                 plugin="heretic.scorers.keyword_rate.KeywordRate",


### PR DESCRIPTION
## Summary
Invalid scorer instance names now fail during config validation instead of reaching evaluator setup.

This catches whitespace-only names, embedded whitespace such as tabs or newlines, and dotted names before they can form unusable `[scorer.ClassName_<instance_name>]` namespaces.

## Validation
- `PYTHONPATH=src python -m unittest discover -s tests -p test_config.py`
- `uv run ruff format --check src/heretic/config.py tests/test_config.py`
- `uv run ruff check --extend-select I src/heretic/config.py tests/test_config.py`
- `uv run ty check src/heretic/config.py tests/test_config.py`

