### PR TITLE
feat: try Suggestion of Blacksmith

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   checks:
     name: Check and build (Python ${{ matrix.python-version }})
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Trying this "drop in replacement" suggestion of using: `blacksmith-4vcpu-ubuntu-2404` instead of `ubuntu-latest` for Github CI tests...

Not sure how reliable it would be or even worth it or not. Let's see.

## Suggested by @red40maxxer on discord.