### PR TITLE
feat/fix(ara): Save-time model tensor integrity check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,6 @@ wheels/
 # Residual plots
 /plots/
 
-# Trial saves and upload staging
+# Preflight saves and upload staging
 /heretic-preflight-*/
 /heretic-upload-*/

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,5 @@ wheels/
 # Residual plots
 /plots/
 
-# Preflight saves and upload staging
-/heretic-preflight-*/
-/heretic-upload-*/
+# Preflight and upload staging
+/heretic-*/

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ wheels/
 
 # Residual plots
 /plots/
+
+# Trial saves and upload staging
+/heretic-preflight-*/
+/heretic-upload-*/

--- a/src/heretic/config.py
+++ b/src/heretic/config.py
@@ -278,24 +278,11 @@ class Settings(BaseSettings):
         description="Directory to save and load study progress to/from.",
     )
 
-    preflight_save_check: bool = Field(
+    preflight_check: bool = Field(
         default=True,
         description=(
-            "Whether to verify that this environment saves the model faithfully, by "
-            "writing a preflight save before optimization and comparing it to the "
-            "source checkpoint. A difference prompts whether to continue; turning "
-            "this off skips only the preflight save, not the checks after saving "
-            "and before uploading."
-        ),
-    )
-
-    # Defaults to the working directory rather than a temporary one: /tmp is usually
-    # tmpfs, which would put a multi-gigabyte model copy in RAM.
-    scratch_directory: str = Field(
-        default=".",
-        description=(
-            "Directory where temporary model copies (the preflight save and upload "
-            "staging) are written."
+            "Whether to check that this environment can save the model faithfully, "
+            "by writing a throwaway save before optimization."
         ),
     )
 

--- a/src/heretic/config.py
+++ b/src/heretic/config.py
@@ -278,6 +278,29 @@ class Settings(BaseSettings):
         description="Directory to save and load study progress to/from.",
     )
 
+    preflight_save_check: bool = Field(
+        default=True,
+        description=(
+            "Whether to check that this environment can serialize the model correctly, "
+            "by saving it once before optimization starts. Turning this off skips only "
+            "the early warning; the model is still checked after saving and before uploading."
+        ),
+    )
+
+    # These default to the working directory rather than to a temporary one because
+    # /tmp is tmpfs on most modern Linux systems, which would put a trial save of a
+    # dequantized gpt-oss (about 39 GB) in RAM while the free space check reported
+    # tmpfs's nominal size and passed.
+    preflight_directory: str = Field(
+        default=".",
+        description="Directory to write the trial save to.",
+    )
+
+    upload_directory: str = Field(
+        default=".",
+        description="Directory to assemble the model in before uploading it.",
+    )
+
     benchmarks: list[BenchmarkSpecification] = Field(
         default=[
             BenchmarkSpecification(

--- a/src/heretic/config.py
+++ b/src/heretic/config.py
@@ -281,24 +281,22 @@ class Settings(BaseSettings):
     preflight_save_check: bool = Field(
         default=True,
         description=(
-            "Whether to check that this environment can serialize the model correctly, "
-            "by saving it once before optimization starts. Turning this off skips only "
-            "the early warning; the model is still checked after saving and before uploading."
+            "Whether to verify that this environment saves the model faithfully, by "
+            "writing a preflight save before optimization and comparing it to the "
+            "source checkpoint. A difference prompts whether to continue; turning "
+            "this off skips only the preflight save, not the checks after saving "
+            "and before uploading."
         ),
     )
 
-    # These default to the working directory rather than to a temporary one because
-    # /tmp is tmpfs on most modern Linux systems, which would put a trial save of a
-    # dequantized gpt-oss (about 39 GB) in RAM while the free space check reported
-    # tmpfs's nominal size and passed.
-    preflight_directory: str = Field(
+    # Defaults to the working directory rather than a temporary one: /tmp is usually
+    # tmpfs, which would put a multi-gigabyte model copy in RAM.
+    scratch_directory: str = Field(
         default=".",
-        description="Directory to write the trial save to.",
-    )
-
-    upload_directory: str = Field(
-        default=".",
-        description="Directory to assemble the model in before uploading it.",
+        description=(
+            "Directory where temporary model copies (the preflight save and upload "
+            "staging) are written."
+        ),
     )
 
     benchmarks: list[BenchmarkSpecification] = Field(

--- a/src/heretic/main.py
+++ b/src/heretic/main.py
@@ -12,6 +12,7 @@ patch_tqdm()
 import logging
 import math
 import os
+import shutil
 import sys
 import time
 import warnings
@@ -37,6 +38,7 @@ from accelerate.utils import (
     is_xpu_available,
 )
 from huggingface_hub import ModelCard, ModelCardData
+from huggingface_hub.errors import EntryNotFoundError, RepositoryNotFoundError
 from lm_eval.models.huggingface import HFLM
 from optuna import Trial, TrialPruned
 from optuna.exceptions import ExperimentalWarning
@@ -54,6 +56,7 @@ from .analyzer import Analyzer
 from .config import QuantizationMethod, RowNormalization, Settings
 from .evaluator import Evaluator
 from .model import AbliterationParameters, ARAParameters, Model, get_model_class
+from .tensor_check import CheckResult, verify_checkpoint
 from .utils import (
     empty_cache,
     format_duration,
@@ -67,6 +70,103 @@ from .utils import (
     prompt_select,
     prompt_text,
 )
+
+
+def verification_applies(settings: Settings) -> bool:
+    # An ARA-LoRA run writes an adapter, whose tensor names bear no relation to any
+    # source checkpoint. That case is excluded rather than given a second invariant.
+    return not (settings.use_ara and settings.use_ara_lora)
+
+
+def confirm_upload(result: CheckResult) -> bool:
+    return (
+        prompt_select(
+            f"Upload anyway, with {len(result.unclaimed_extra)} unexpected tensor(s)?",
+            choices=[
+                Choice(title="Upload the model", value="upload"),
+                Choice(title="Cancel", value="cancel"),
+            ],
+        )
+        == "upload"
+    )
+
+
+def compensating_model_card(repo_id: str, token: str) -> ModelCard:
+    """
+    The card push_to_hub would have written when Heretic has none of its own.
+
+    It loads the card already on the repository and only generates one when there is
+    none, which is what keeps an existing card from being overwritten. A repository
+    that does not exist counts as one without a card: the proposed name is usually new,
+    and it is created after verification rather than before it.
+    """
+    try:
+        return ModelCard.load(repo_id, token=token)
+    except (EntryNotFoundError, RepositoryNotFoundError):
+        return ModelCard.from_template(ModelCardData(library_name="transformers"))
+
+
+def stage_for_upload(model: Model, settings: Settings, card: ModelCard) -> Path:
+    """
+    Writes the model, the tokenizer and the card into a directory beside the one kept
+    from any previous upload, and swaps the new one into place once it is complete.
+
+    push_to_hub cannot be used here. It saves into a temporary directory that is
+    destroyed before it returns, and reading back what was actually written is the only
+    way to catch a serialization bug.
+
+    Anything already kept has to survive every step below, all of which can fail: a
+    full-precision reload that may exhaust memory, a save that raises part way through
+    on some transformers versions, a full disk, and Ctrl+C, which is a BaseException
+    and ends the session outright. So nothing is ever written into the kept directory.
+    """
+    staging = (
+        Path(settings.upload_directory) / f"heretic-upload-{Path(settings.model).name}"
+    )
+    incoming = staging.with_name(staging.name + ".new")
+    previous = staging.with_name(staging.name + ".old")
+
+    # If a previous attempt died between the two renames below, the kept directory is
+    # gone and this is the only complete copy left.
+    if previous.exists():
+        if staging.exists():
+            shutil.rmtree(previous)
+        else:
+            previous.rename(staging)
+
+    # Usually incomplete, and removed without asking whether it is. Left in place it
+    # would be written into by the save below and then uploaded along with it, which is
+    # how a stray adapter_config.json from an abandoned run gets published and makes
+    # the whole repository load as an adapter.
+    if incoming.exists():
+        shutil.rmtree(incoming)
+
+    if settings.use_ara:
+        print("Uploading model...")
+        merged_model = model.model
+    else:
+        print("Uploading merged model...")
+        merged_model = model.get_merged_model()
+
+    merged_model.save_pretrained(str(incoming))
+    del merged_model
+    empty_cache()
+    model.tokenizer.save_pretrained(str(incoming))
+
+    # After both saves. PeftModel.save_pretrained writes a README of its own, and it
+    # replaces the front matter wholesale, which would drop Heretic's tags.
+    card.save(incoming / huggingface_hub.constants.REPOCARD_NAME)
+
+    # Swapped in on completeness rather than on the verdict. A rejected artifact is
+    # still the user's abliterated model, and a failed check means "do not publish
+    # this", never "do not keep this".
+    if staging.exists():
+        staging.rename(previous)
+    incoming.rename(staging)
+    if previous.exists():
+        shutil.rmtree(previous)
+
+    return staging
 
 
 def obtain_merge_strategy(settings: Settings) -> str | None:
@@ -895,6 +995,13 @@ def run():
                                 empty_cache()
                                 model.tokenizer.save_pretrained(save_directory)
 
+                                if verification_applies(settings):
+                                    verify_checkpoint(
+                                        Path(save_directory),
+                                        model.source_index,
+                                        model.check_captures,
+                                    )
+
                             print(f"Model saved to [bold]{save_directory}[/].")
 
                         case "Upload the model to Hugging Face":
@@ -935,38 +1042,25 @@ def run():
                             if strategy is None:
                                 continue
 
-                            if strategy == "adapter":
-                                print("Uploading LoRA adapter...")
-                                model.model.push_to_hub(
-                                    repo_id,
-                                    private=private,
-                                    token=token,
-                                )
-                            else:
-                                if settings.use_ara:
-                                    print("Uploading model...")
-                                    merged_model = model.model
-                                else:
-                                    print("Uploading merged model...")
-                                    merged_model = model.get_merged_model()
-                                merged_model.push_to_hub(
-                                    repo_id,
-                                    private=private,
-                                    token=token,
-                                )
-                                del merged_model
-                                empty_cache()
-                                model.tokenizer.push_to_hub(
-                                    repo_id,
-                                    private=private,
-                                    token=token,
-                                )
+                            # create_repo normalizes this, but it does not run until
+                            # after the model has been checked, and the card below is
+                            # looked up before that. A name without a namespace would
+                            # not find the card already on the repository, and would
+                            # overwrite it with a generated one.
+                            if "/" not in repo_id:
+                                repo_id = f"{user['name']}/{repo_id}"
 
                             # If the model path exists locally and includes the
                             # card, use it directly. If the model path doesn't
                             # exist locally, it can be assumed to be a model
                             # hosted on the Hugging Face Hub, in which case
                             # we can retrieve the model card.
+                            #
+                            # This runs before the upload rather than after it, because
+                            # the card is now written into the folder that gets
+                            # uploaded. That turns the fetch below into something that
+                            # can fail before anything has been published, so a card
+                            # that cannot be read falls back rather than propagating.
                             model_path = Path(settings.model)
                             if model_path.exists():
                                 card_path = (
@@ -977,7 +1071,10 @@ def run():
                                 else:
                                     card = None
                             else:
-                                card = ModelCard.load(settings.model)
+                                try:
+                                    card = ModelCard.load(settings.model)
+                                except Exception:
+                                    card = None
                             if card is not None:
                                 if card.data is None:
                                     card.data = ModelCardData()
@@ -1004,7 +1101,54 @@ def run():
                                     )
                                     + card.text
                                 )
-                                card.push_to_hub(repo_id, token=token)
+
+                            if strategy == "adapter":
+                                print("Uploading LoRA adapter...")
+                                model.model.push_to_hub(
+                                    repo_id,
+                                    private=private,
+                                    token=token,
+                                )
+                                if card is not None:
+                                    card.push_to_hub(repo_id, token=token)
+                            else:
+                                staging_directory = stage_for_upload(
+                                    model,
+                                    settings,
+                                    card
+                                    if card is not None
+                                    else compensating_model_card(repo_id, token),
+                                )
+
+                                if verification_applies(settings):
+                                    verify_checkpoint(
+                                        staging_directory,
+                                        model.source_index,
+                                        model.check_captures,
+                                        context="upload",
+                                        confirm=confirm_upload,
+                                    )
+
+                                # Created only now, so that a model which fails the
+                                # check leaves nothing behind on the Hub. Every
+                                # argument here is one push_to_hub was supplying:
+                                # without exist_ok every upload to an existing
+                                # repository fails, without private the first upload of
+                                # a model marked private is published publicly, and
+                                # without token the upload falls back to an ambient
+                                # credential that Heretic deliberately never writes.
+                                repo_id = huggingface_hub.create_repo(
+                                    repo_id,
+                                    private=private,
+                                    token=token,
+                                    exist_ok=True,
+                                ).repo_id
+                                huggingface_hub.upload_folder(
+                                    repo_id=repo_id,
+                                    folder_path=staging_directory,
+                                    token=token,
+                                )
+                                shutil.rmtree(staging_directory, ignore_errors=True)
 
                             print(f"Model uploaded to [bold]{repo_id}[/].")
 

--- a/src/heretic/main.py
+++ b/src/heretic/main.py
@@ -56,7 +56,7 @@ from .analyzer import Analyzer
 from .config import QuantizationMethod, RowNormalization, Settings
 from .evaluator import Evaluator
 from .model import AbliterationParameters, ARAParameters, Model, get_model_class
-from .tensor_check import CheckResult, verify_checkpoint
+from .tensor_check import CheckResult, CheckSite, Verdict, compare_checkpoint
 from .utils import (
     empty_cache,
     format_duration,
@@ -73,32 +73,43 @@ from .utils import (
 
 
 def verification_applies(settings: Settings) -> bool:
-    # An ARA-LoRA run writes an adapter, whose tensor names bear no relation to any
-    # source checkpoint. That case is excluded rather than given a second invariant.
+    # An ARA-LoRA run writes an adapter, whose names bear no relation to the source.
     return not (settings.use_ara and settings.use_ara_lora)
 
 
 def confirm_upload(result: CheckResult) -> bool:
-    return (
-        prompt_select(
-            f"Upload anyway, with {len(result.unclaimed_extra)} unexpected tensor(s)?",
+    if result.verdict == Verdict.NO_WEIGHTS:
+        message = (
+            f"The staged model contains no weights ({result.reason}). Upload anyway?"
+        )
+    else:
+        message = (
+            "The staged model differs from the source checkpoint "
+            f"({len(result.absent)} absent, {len(result.extra)} extra, "
+            f"{len(result.shape_mismatches)} shape). Upload anyway?"
+        )
+
+    # Cancel first: bare Enter must not publish. questionary turns Ctrl+C into None
+    # and a closed input raises EOFError; both cancel.
+    try:
+        choice = prompt_select(
+            message,
             choices=[
-                Choice(title="Upload the model", value="upload"),
                 Choice(title="Cancel", value="cancel"),
+                Choice(title="Upload the model anyway", value="upload"),
             ],
         )
-        == "upload"
-    )
+    except (KeyboardInterrupt, EOFError):
+        choice = None
+
+    return choice == "upload"
 
 
-def compensating_model_card(repo_id: str, token: str) -> ModelCard:
+def fallback_model_card(repo_id: str, token: str) -> ModelCard:
     """
-    The card push_to_hub would have written when Heretic has none of its own.
-
-    It loads the card already on the repository and only generates one when there is
-    none, which is what keeps an existing card from being overwritten. A repository
-    that does not exist counts as one without a card: the proposed name is usually new,
-    and it is created after verification rather than before it.
+    Loads the card already on the repository, generating one only when there is
+    none, so an existing remote card is never overwritten. A missing repository
+    counts as no card: it is created only after verification.
     """
     try:
         return ModelCard.load(repo_id, token=token)
@@ -108,38 +119,14 @@ def compensating_model_card(repo_id: str, token: str) -> ModelCard:
 
 def stage_for_upload(model: Model, settings: Settings, card: ModelCard) -> Path:
     """
-    Writes the model, the tokenizer and the card into a directory beside the one kept
-    from any previous upload, and swaps the new one into place once it is complete.
-
-    push_to_hub cannot be used here. It saves into a temporary directory that is
-    destroyed before it returns, and reading back what was actually written is the only
-    way to catch a serialization bug.
-
-    Anything already kept has to survive every step below, all of which can fail: a
-    full-precision reload that may exhaust memory, a save that raises part way through
-    on some transformers versions, a full disk, and Ctrl+C, which is a BaseException
-    and ends the session outright. So nothing is ever written into the kept directory.
+    Writes the model, the tokenizer and the card into a local staging directory.
+    push_to_hub saves into a temporary directory destroyed before it returns, and
+    reading back what was actually written is the only way to catch a serialization
+    bug.
     """
     staging = (
-        Path(settings.upload_directory) / f"heretic-upload-{Path(settings.model).name}"
+        Path(settings.scratch_directory) / f"heretic-upload-{Path(settings.model).name}"
     )
-    incoming = staging.with_name(staging.name + ".new")
-    previous = staging.with_name(staging.name + ".old")
-
-    # If a previous attempt died between the two renames below, the kept directory is
-    # gone and this is the only complete copy left.
-    if previous.exists():
-        if staging.exists():
-            shutil.rmtree(previous)
-        else:
-            previous.rename(staging)
-
-    # Usually incomplete, and removed without asking whether it is. Left in place it
-    # would be written into by the save below and then uploaded along with it, which is
-    # how a stray adapter_config.json from an abandoned run gets published and makes
-    # the whole repository load as an adapter.
-    if incoming.exists():
-        shutil.rmtree(incoming)
 
     if settings.use_ara:
         print("Uploading model...")
@@ -148,23 +135,19 @@ def stage_for_upload(model: Model, settings: Settings, card: ModelCard) -> Path:
         print("Uploading merged model...")
         merged_model = model.get_merged_model()
 
-    merged_model.save_pretrained(str(incoming))
+    # Cleared only once the merge product exists, so a failed merge cannot cost a
+    # retained artifact; a fresh directory keeps leftovers from being uploaded.
+    if staging.exists():
+        shutil.rmtree(staging)
+
+    merged_model.save_pretrained(str(staging))
     del merged_model
     empty_cache()
-    model.tokenizer.save_pretrained(str(incoming))
+    model.tokenizer.save_pretrained(str(staging))
 
-    # After both saves. PeftModel.save_pretrained writes a README of its own, and it
-    # replaces the front matter wholesale, which would drop Heretic's tags.
-    card.save(incoming / huggingface_hub.constants.REPOCARD_NAME)
-
-    # Swapped in on completeness rather than on the verdict. A rejected artifact is
-    # still the user's abliterated model, and a failed check means "do not publish
-    # this", never "do not keep this".
-    if staging.exists():
-        staging.rename(previous)
-    incoming.rename(staging)
-    if previous.exists():
-        shutil.rmtree(previous)
+    # After both saves: PeftModel.save_pretrained writes a README of its own,
+    # replacing the front matter and dropping Heretic's tags.
+    card.save(staging / huggingface_hub.constants.REPOCARD_NAME)
 
     return staging
 
@@ -996,11 +979,23 @@ def run():
                                 model.tokenizer.save_pretrained(save_directory)
 
                                 if verification_applies(settings):
-                                    verify_checkpoint(
-                                        Path(save_directory),
-                                        model.source_index,
-                                        model.check_captures,
+                                    result = compare_checkpoint(
+                                        Path(save_directory), model.source_index
                                     )
+                                    if result.verdict == Verdict.UNAVAILABLE:
+                                        print(
+                                            f"* Tensor check skipped: {result.reason}"
+                                        )
+                                    elif result.verdict == Verdict.CLEAN:
+                                        print(
+                                            "* Saved model structure matches the "
+                                            "source checkpoint"
+                                        )
+                                    else:
+                                        report = result.describe(
+                                            CheckSite.POST_SAVE, Path(save_directory)
+                                        )
+                                        print(f"[yellow]{report}[/]")
 
                             print(f"Model saved to [bold]{save_directory}[/].")
 
@@ -1042,11 +1037,9 @@ def run():
                             if strategy is None:
                                 continue
 
-                            # create_repo normalizes this, but it does not run until
-                            # after the model has been checked, and the card below is
-                            # looked up before that. A name without a namespace would
-                            # not find the card already on the repository, and would
-                            # overwrite it with a generated one.
+                            # The card lookup below runs before create_repo can
+                            # normalize the id; a bare name would miss the existing
+                            # remote card and overwrite it.
                             if "/" not in repo_id:
                                 repo_id = f"{user['name']}/{repo_id}"
 
@@ -1056,11 +1049,8 @@ def run():
                             # hosted on the Hugging Face Hub, in which case
                             # we can retrieve the model card.
                             #
-                            # This runs before the upload rather than after it, because
-                            # the card is now written into the folder that gets
-                            # uploaded. That turns the fetch below into something that
-                            # can fail before anything has been published, so a card
-                            # that cannot be read falls back rather than propagating.
+                            # Runs before the upload now, so a failed card fetch must
+                            # fall back rather than propagate and kill the upload.
                             model_path = Path(settings.model)
                             if model_path.exists():
                                 card_path = (
@@ -1117,26 +1107,32 @@ def run():
                                     settings,
                                     card
                                     if card is not None
-                                    else compensating_model_card(repo_id, token),
+                                    else fallback_model_card(repo_id, token),
                                 )
 
                                 if verification_applies(settings):
-                                    verify_checkpoint(
-                                        staging_directory,
-                                        model.source_index,
-                                        model.check_captures,
-                                        context="upload",
-                                        confirm=confirm_upload,
+                                    result = compare_checkpoint(
+                                        staging_directory, model.source_index
                                     )
+                                    if result.verdict == Verdict.UNAVAILABLE:
+                                        print(
+                                            f"* Tensor check skipped: {result.reason}"
+                                        )
+                                    elif result.verdict != Verdict.CLEAN:
+                                        report = result.describe(
+                                            CheckSite.UPLOAD, staging_directory
+                                        )
+                                        print(f"[yellow]{report}[/]")
+                                        if not confirm_upload(result):
+                                            print(
+                                                "Upload cancelled. The model is "
+                                                f"still at [bold]{staging_directory}[/]."
+                                            )
+                                            continue
 
-                                # Created only now, so that a model which fails the
-                                # check leaves nothing behind on the Hub. Every
-                                # argument here is one push_to_hub was supplying:
-                                # without exist_ok every upload to an existing
-                                # repository fails, without private the first upload of
-                                # a model marked private is published publicly, and
-                                # without token the upload falls back to an ambient
-                                # credential that Heretic deliberately never writes.
+                                # Created only after the check, so a cancelled upload
+                                # leaves nothing on the Hub. exist_ok, private and
+                                # token are all arguments push_to_hub was supplying.
                                 repo_id = huggingface_hub.create_repo(
                                     repo_id,
                                     private=private,

--- a/src/heretic/main.py
+++ b/src/heretic/main.py
@@ -20,6 +20,7 @@ from dataclasses import asdict
 from importlib.metadata import version
 from os.path import commonprefix
 from pathlib import Path
+from tempfile import mkdtemp
 from typing import Any
 
 import huggingface_hub
@@ -38,7 +39,6 @@ from accelerate.utils import (
     is_xpu_available,
 )
 from huggingface_hub import ModelCard, ModelCardData
-from huggingface_hub.errors import EntryNotFoundError, RepositoryNotFoundError
 from lm_eval.models.huggingface import HFLM
 from optuna import Trial, TrialPruned
 from optuna.exceptions import ExperimentalWarning
@@ -56,7 +56,7 @@ from .analyzer import Analyzer
 from .config import QuantizationMethod, RowNormalization, Settings
 from .evaluator import Evaluator
 from .model import AbliterationParameters, ARAParameters, Model, get_model_class
-from .tensor_check import CheckResult, CheckSite, Verdict, compare_checkpoint
+from .tensor_check import check_tensors
 from .utils import (
     empty_cache,
     format_duration,
@@ -70,86 +70,6 @@ from .utils import (
     prompt_select,
     prompt_text,
 )
-
-
-def verification_applies(settings: Settings) -> bool:
-    # An ARA-LoRA run writes an adapter, whose names bear no relation to the source.
-    return not (settings.use_ara and settings.use_ara_lora)
-
-
-def confirm_upload(result: CheckResult) -> bool:
-    if result.verdict == Verdict.NO_WEIGHTS:
-        message = (
-            f"The staged model contains no weights ({result.reason}). Upload anyway?"
-        )
-    else:
-        message = (
-            "The staged model differs from the source checkpoint "
-            f"({len(result.absent)} absent, {len(result.extra)} extra, "
-            f"{len(result.shape_mismatches)} shape). Upload anyway?"
-        )
-
-    # Cancel first: bare Enter must not publish. questionary turns Ctrl+C into None
-    # and a closed input raises EOFError; both cancel.
-    try:
-        choice = prompt_select(
-            message,
-            choices=[
-                Choice(title="Cancel", value="cancel"),
-                Choice(title="Upload the model anyway", value="upload"),
-            ],
-        )
-    except (KeyboardInterrupt, EOFError):
-        choice = None
-
-    return choice == "upload"
-
-
-def fallback_model_card(repo_id: str, token: str) -> ModelCard:
-    """
-    Loads the card already on the repository, generating one only when there is
-    none, so an existing remote card is never overwritten. A missing repository
-    counts as no card: it is created only after verification.
-    """
-    try:
-        return ModelCard.load(repo_id, token=token)
-    except (EntryNotFoundError, RepositoryNotFoundError):
-        return ModelCard.from_template(ModelCardData(library_name="transformers"))
-
-
-def stage_for_upload(model: Model, settings: Settings, card: ModelCard) -> Path:
-    """
-    Writes the model, the tokenizer and the card into a local staging directory.
-    push_to_hub saves into a temporary directory destroyed before it returns, and
-    reading back what was actually written is the only way to catch a serialization
-    bug.
-    """
-    staging = (
-        Path(settings.scratch_directory) / f"heretic-upload-{Path(settings.model).name}"
-    )
-
-    if settings.use_ara:
-        print("Uploading model...")
-        merged_model = model.model
-    else:
-        print("Uploading merged model...")
-        merged_model = model.get_merged_model()
-
-    # Cleared only once the merge product exists, so a failed merge cannot cost a
-    # retained artifact; a fresh directory keeps leftovers from being uploaded.
-    if staging.exists():
-        shutil.rmtree(staging)
-
-    merged_model.save_pretrained(str(staging))
-    del merged_model
-    empty_cache()
-    model.tokenizer.save_pretrained(str(staging))
-
-    # After both saves: PeftModel.save_pretrained writes a README of its own,
-    # replacing the front matter and dropping Heretic's tags.
-    card.save(staging / huggingface_hub.constants.REPOCARD_NAME)
-
-    return staging
 
 
 def obtain_merge_strategy(settings: Settings) -> str | None:
@@ -978,24 +898,7 @@ def run():
                                 empty_cache()
                                 model.tokenizer.save_pretrained(save_directory)
 
-                                if verification_applies(settings):
-                                    result = compare_checkpoint(
-                                        Path(save_directory), model.source_index
-                                    )
-                                    if result.verdict == Verdict.UNAVAILABLE:
-                                        print(
-                                            f"* Tensor check skipped: {result.reason}"
-                                        )
-                                    elif result.verdict == Verdict.CLEAN:
-                                        print(
-                                            "* Saved model structure matches the "
-                                            "source checkpoint"
-                                        )
-                                    else:
-                                        report = result.describe(
-                                            CheckSite.POST_SAVE, Path(save_directory)
-                                        )
-                                        print(f"[yellow]{report}[/]")
+                                check_tensors(model.source_shapes, save_directory)
 
                             print(f"Model saved to [bold]{save_directory}[/].")
 
@@ -1037,20 +940,49 @@ def run():
                             if strategy is None:
                                 continue
 
-                            # The card lookup below runs before create_repo can
-                            # normalize the id; a bare name would miss the existing
-                            # remote card and overwrite it.
-                            if "/" not in repo_id:
-                                repo_id = f"{user['name']}/{repo_id}"
+                            if strategy == "adapter":
+                                print("Uploading LoRA adapter...")
+                                model.model.push_to_hub(
+                                    repo_id,
+                                    private=private,
+                                    token=token,
+                                )
+                            else:
+                                if settings.use_ara:
+                                    print("Uploading model...")
+                                    merged_model = model.model
+                                else:
+                                    print("Uploading merged model...")
+                                    merged_model = model.get_merged_model()
+
+                                if model.source_shapes:
+                                    try:
+                                        staging = mkdtemp("", "heretic-upload-", ".")
+                                        print(f"Verifying {staging}...", markup=False)
+                                        merged_model.save_pretrained(staging)
+                                        if check_tensors(model.source_shapes, staging):
+                                            shutil.rmtree(staging, ignore_errors=True)
+                                    except Exception as error:
+                                        print(f"* Check skipped: {error}", markup=False)
+
+                                merged_model.push_to_hub(
+                                    repo_id,
+                                    private=private,
+                                    token=token,
+                                )
+                                del merged_model
+                                empty_cache()
+                                model.tokenizer.push_to_hub(
+                                    repo_id,
+                                    private=private,
+                                    token=token,
+                                )
 
                             # If the model path exists locally and includes the
                             # card, use it directly. If the model path doesn't
                             # exist locally, it can be assumed to be a model
                             # hosted on the Hugging Face Hub, in which case
                             # we can retrieve the model card.
-                            #
-                            # Runs before the upload now, so a failed card fetch must
-                            # fall back rather than propagate and kill the upload.
                             model_path = Path(settings.model)
                             if model_path.exists():
                                 card_path = (
@@ -1061,10 +993,7 @@ def run():
                                 else:
                                     card = None
                             else:
-                                try:
-                                    card = ModelCard.load(settings.model)
-                                except Exception:
-                                    card = None
+                                card = ModelCard.load(settings.model)
                             if card is not None:
                                 if card.data is None:
                                     card.data = ModelCardData()
@@ -1091,60 +1020,7 @@ def run():
                                     )
                                     + card.text
                                 )
-
-                            if strategy == "adapter":
-                                print("Uploading LoRA adapter...")
-                                model.model.push_to_hub(
-                                    repo_id,
-                                    private=private,
-                                    token=token,
-                                )
-                                if card is not None:
-                                    card.push_to_hub(repo_id, token=token)
-                            else:
-                                staging_directory = stage_for_upload(
-                                    model,
-                                    settings,
-                                    card
-                                    if card is not None
-                                    else fallback_model_card(repo_id, token),
-                                )
-
-                                if verification_applies(settings):
-                                    result = compare_checkpoint(
-                                        staging_directory, model.source_index
-                                    )
-                                    if result.verdict == Verdict.UNAVAILABLE:
-                                        print(
-                                            f"* Tensor check skipped: {result.reason}"
-                                        )
-                                    elif result.verdict != Verdict.CLEAN:
-                                        report = result.describe(
-                                            CheckSite.UPLOAD, staging_directory
-                                        )
-                                        print(f"[yellow]{report}[/]")
-                                        if not confirm_upload(result):
-                                            print(
-                                                "Upload cancelled. The model is "
-                                                f"still at [bold]{staging_directory}[/]."
-                                            )
-                                            continue
-
-                                # Created only after the check, so a cancelled upload
-                                # leaves nothing on the Hub. exist_ok, private and
-                                # token are all arguments push_to_hub was supplying.
-                                repo_id = huggingface_hub.create_repo(
-                                    repo_id,
-                                    private=private,
-                                    token=token,
-                                    exist_ok=True,
-                                ).repo_id
-                                huggingface_hub.upload_folder(
-                                    repo_id=repo_id,
-                                    folder_path=staging_directory,
-                                    token=token,
-                                )
-                                shutil.rmtree(staging_directory, ignore_errors=True)
+                                card.push_to_hub(repo_id, token=token)
 
                             print(f"Model uploaded to [bold]{repo_id}[/].")
 

--- a/src/heretic/model.py
+++ b/src/heretic/model.py
@@ -2,21 +2,17 @@
 # Copyright (C) 2025-2026  Philipp Emanuel Weidmann <pew@worldwidemann.com> + contributors
 
 import math
-import shutil
-import time
 from contextlib import suppress
 from dataclasses import dataclass
-from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import Any, Callable, Type, TypeAlias, cast
 
 import bitsandbytes as bnb
-import huggingface_hub
 import torch
 import torch.linalg as LA
 import torch.nn.functional as F
 from peft import LoraConfig, PeftModel, get_peft_model
 from peft.tuners.lora.layer import Linear
-from questionary import Choice
 from torch import FloatTensor, LongTensor, Tensor
 from torch.nn import Module, ModuleList
 from torch.optim import LBFGS
@@ -37,21 +33,8 @@ from transformers.generation import (
 )
 
 from .config import QuantizationMethod, RowNormalization, Settings
-from .tensor_check import (
-    CheckpointIndex,
-    CheckSite,
-    Verdict,
-    compare_checkpoint,
-    read_checkpoint_index,
-)
-from .utils import (
-    Prompt,
-    batchify,
-    empty_cache,
-    mean_distances_to_knn,
-    print,
-    prompt_select,
-)
+from .tensor_check import check_tensors, tensor_shapes
+from .utils import Prompt, batchify, empty_cache, mean_distances_to_knn, print
 
 
 def get_model_class(
@@ -90,15 +73,11 @@ class ARAParameters:
 ModuleIO: TypeAlias = list[dict[str, dict[int, tuple[Tensor, Tensor]]]]
 
 
-def directory_size(directory: Path) -> int:
-    return sum(path.stat().st_size for path in directory.rglob("*") if path.is_file())
-
-
 class Model:
     model: PreTrainedModel | PeftModel
     tokenizer: PreTrainedTokenizerBase
     peft_config: LoraConfig
-    source_index: CheckpointIndex
+    source_shapes: dict[str, tuple[int, ...]]
 
     def __init__(self, settings: Settings):
         self.settings = settings
@@ -185,36 +164,28 @@ class Model:
         if self.model is None:
             raise Exception("Failed to load model with all configured dtypes.")
 
-        # Collect the loader's progress bars now; collected later, they erase
-        # themselves relative to wherever the cursor has moved to.
-        empty_cache()
+        adapter_save = self.model._hf_peft_config_loaded or (
+            settings.use_ara and settings.use_ara_lora
+        )
+        # An adapter save writes names bearing no relation to the source checkpoint.
+        self.source_shapes = {} if adapter_save else tensor_shapes(settings.model)
 
-        self._prepare_tensor_check()
-
-        preflight_target = self._preflight_save_target()
-        if preflight_target is not None and not self._announce_preflight_save(
-            preflight_target
+        # A quantized load serializes bitsandbytes state the source has no names for.
+        if (
+            settings.preflight_check
+            and self.source_shapes
+            and settings.evaluate_model is None
+            and settings.quantization == QuantizationMethod.NONE
         ):
-            preflight_target = None
-
-        if preflight_target == "loaded":
-            # Before _apply_lora: a LoRA-wrapped tree serializes adapter names,
-            # not the model's.
-            assert isinstance(self.model, PreTrainedModel)
-            self._preflight_save(self.model)
+            try:
+                with TemporaryDirectory(dir=".", prefix="heretic-preflight-") as path:
+                    self.model.save_pretrained(path)
+                    check_tensors(self.source_shapes, path)
+            except Exception as error:
+                print(f"* Preflight save failed: {error}", markup=False)
 
         if not settings.use_ara or settings.use_ara_lora:
             self._apply_lora()
-
-        # The save on this path writes get_merged_model()'s product, not anything
-        # already in memory.
-        if preflight_target == "merged":
-            merged_model = self.get_merged_model()
-            try:
-                self._preflight_save(merged_model)
-            finally:
-                del merged_model
-                empty_cache()
 
         # LoRA B matrices are initialized to zero by default in PEFT,
         # so we don't need to do anything manually.
@@ -229,219 +200,6 @@ class Model:
                 all_components[component] += len(modules)
         for component, count in all_components.items():
             print(f"  * [bold]{component}[/]: [bold]{count}[/] modules total")
-
-    def _prepare_tensor_check(self):
-        """
-        Reads the source checkpoint's tensor names, so saves can be compared to them.
-        Best effort: a source that cannot be read must not stop the run.
-        """
-        self.source_index = {}
-
-        # save_pretrained on a PEFT-loaded model (full weights beside the adapter
-        # config included) writes only the adapter, so there is no model save to
-        # verify.
-        if self.model._hf_peft_config_loaded:
-            print(
-                "* Saved models cannot be verified (this source loads as a PEFT "
-                "adapter, so saving writes the adapter, not the model)"
-            )
-            return
-
-        try:
-            source_directory = Path(self.settings.model)
-            if not source_directory.is_dir():
-                # Only after the load is the cached snapshot known to hold weights.
-                source_directory = Path(
-                    huggingface_hub.snapshot_download(
-                        self.settings.model,
-                        local_files_only=True,
-                    )
-                )
-
-            self.source_index = read_checkpoint_index(source_directory)
-        except Exception as error:
-            self.source_index = {}
-            print(f"* Saved models cannot be verified ({error})")
-            return
-
-        if not self.source_index:
-            print("* Saved models cannot be verified (the source has no safetensors)")
-
-    def _preflight_save_target(self) -> str | None:
-        """
-        Returns "loaded" for the model as loaded, "merged" for what get_merged_model()
-        produces, or None to skip the preflight save.
-        """
-        settings = self.settings
-
-        if not settings.preflight_save_check or not self.source_index:
-            return None
-
-        # An ARA-LoRA run writes an adapter; a full-model preflight save would
-        # predict nothing about it.
-        if settings.use_ara and settings.use_ara_lora:
-            return None
-
-        # This run returns before it reaches a save.
-        if settings.evaluate_model is not None:
-            return None
-
-        # A preflight save here would flag the bitsandbytes model's quantization
-        # state as differences, on a configuration ARA rejects on its own anyway.
-        if settings.use_ara and settings.quantization != QuantizationMethod.NONE:
-            return None
-
-        # Mirrors the dispatch of the save itself, which selects on use_ara.
-        if settings.use_ara or settings.quantization == QuantizationMethod.NONE:
-            return "loaded"
-
-        return "merged"
-
-    def _preflight_save_directory(self) -> Path:
-        return (
-            Path(self.settings.scratch_directory)
-            / f"heretic-preflight-{Path(self.settings.model).name}"
-        )
-
-    def _source_payload_size(self) -> int:
-        return sum(nbytes for _, nbytes in self.source_index.values())
-
-    def _preflight_save_size(self, model: PreTrainedModel | PeftModel) -> int:
-        # Each term alone under-reports: state_dict misses MXFP4 expert weights
-        # (deregistered until save_pretrained restores them), and the source payload
-        # misses the expansion of a dequantized write.
-        state_dict_size = sum(
-            tensor.numel() * tensor.element_size()
-            for tensor in model.state_dict().values()
-        )
-
-        return int(max(state_dict_size, self._source_payload_size()) * 1.05)
-
-    def _announce_preflight_save(self, target: str) -> bool:
-        """
-        Explains the preflight save; returns False if it should not run after all.
-        """
-        # An unsupported architecture must fail here, not after a countdown and a
-        # full serialization.
-        self.get_layers()
-
-        print()
-
-        if target == "merged":
-            # Warned rather than guarded, matching the save-time merge prompt.
-            print(
-                "Merging into a quantized model reloads it in full precision on "
-                "CPU first. [yellow]This can lead to system freezes if you run "
-                "out of memory.[/]"
-            )
-            estimated_size = self._source_payload_size()
-        else:
-            estimated_size = self._preflight_save_size(self.model)
-
-        print(
-            "Checking that this environment can save the model correctly, before "
-            "spending any time on optimization."
-        )
-        print(
-            f"This writes about [bold]{estimated_size / 1024**3:.1f} GB[/] to "
-            f"[bold]{self._preflight_save_directory()}[/], and removes it again "
-            "afterwards."
-        )
-        print(
-            "Starting in 10 seconds. Press Ctrl+C to skip it, or pass "
-            "[bold]--no-preflight-save-check[/] to skip it in future runs."
-        )
-
-        try:
-            time.sleep(10)
-        except KeyboardInterrupt:
-            print("* Save check skipped")
-            return False
-
-        return True
-
-    def _confirm_continue(self, message: str, continue_title: str) -> bool:
-        # questionary turns Ctrl+C into None and a closed input raises EOFError;
-        # anything but an explicit continue must stop.
-        try:
-            choice = prompt_select(
-                message,
-                [
-                    Choice(title="Stop (recommended)", value="stop"),
-                    Choice(title=continue_title, value="continue"),
-                ],
-            )
-        except (KeyboardInterrupt, EOFError):
-            choice = None
-
-        return choice == "continue"
-
-    def _preflight_save(self, model: PreTrainedModel):
-        directory = self._preflight_save_directory()
-
-        # A stale artifact from an earlier stopped run must not pollute the
-        # comparison; save_pretrained does not clear a directory.
-        if directory.exists():
-            shutil.rmtree(directory)
-
-        try:
-            model.save_pretrained(directory)
-            result = compare_checkpoint(directory, self.source_index)
-        except Exception as error:
-            # Transformers can swallow a Ctrl+C and raise something else; re-raise
-            # so main() sees the interrupt instead of this prompting a user who
-            # just aborted.
-            if isinstance(error.__context__, KeyboardInterrupt):
-                raise
-            print()
-            print(f"[red]This environment cannot save the model: {error}[/]")
-            result = None
-
-        if result is not None and result.verdict == Verdict.CLEAN:
-            shutil.rmtree(directory, ignore_errors=True)
-            print("* This environment saves the model correctly")
-            return
-
-        # Nothing catches exceptions from Model.__init__, so the diagnosis is
-        # printed here and only a one-line summary propagates into the traceback.
-        if result is not None:
-            print()
-            print(f"[red]{result.describe(CheckSite.PREFLIGHT, directory)}[/]")
-            print(f"It occupies {directory_size(directory) / 1024**3:.1f} GB.")
-
-        cannot_save = result is None or result.verdict == Verdict.NO_WEIGHTS
-
-        if cannot_save:
-            continue_run = self._confirm_continue(
-                "Saving will fail the same way at the end of the run. Continue anyway?",
-                "Continue without a working save",
-            )
-        else:
-            continue_run = self._confirm_continue(
-                "The optimized model would be saved by this same environment. "
-                "Continue anyway?",
-                "Continue anyway",
-            )
-
-        if continue_run:
-            shutil.rmtree(directory, ignore_errors=True)
-            return
-
-        if result is None:
-            print(
-                f"The incomplete save has been left at [bold]{directory}[/], "
-                f"occupying {directory_size(directory) / 1024**3:.1f} GB."
-            )
-
-        if cannot_save:
-            raise Exception(
-                "This environment does not save the model correctly (see above)."
-            )
-
-        raise Exception(
-            "Run stopped: the preflight save differs from the source checkpoint "
-            "(see above)."
-        )
 
     def _apply_lora(self):
         # Guard against calling this method at the wrong time.

--- a/src/heretic/model.py
+++ b/src/heretic/model.py
@@ -163,6 +163,8 @@ class Model:
 
         if self.model is None:
             raise Exception("Failed to load model with all configured dtypes.")
+        # Collect the loader's progress bars now; collected later they erase output.
+        empty_cache()
 
         adapter_save = self.model._hf_peft_config_loaded or (
             settings.use_ara and settings.use_ara_lora

--- a/src/heretic/model.py
+++ b/src/heretic/model.py
@@ -16,7 +16,7 @@ import torch.linalg as LA
 import torch.nn.functional as F
 from peft import LoraConfig, PeftModel, get_peft_model
 from peft.tuners.lora.layer import Linear
-from psutil import virtual_memory
+from questionary import Choice
 from torch import FloatTensor, LongTensor, Tensor
 from torch.nn import Module, ModuleList
 from torch.optim import LBFGS
@@ -35,18 +35,23 @@ from transformers import (
 from transformers.generation import (
     GenerateDecoderOnlyOutput,  # ty:ignore[possibly-missing-import]
 )
-from transformers.utils.peft_utils import find_adapter_config_file
 
 from .config import QuantizationMethod, RowNormalization, Settings
 from .tensor_check import (
-    Captures,
     CheckpointIndex,
-    TensorCheckError,
-    capture_state,
+    CheckSite,
+    Verdict,
+    compare_checkpoint,
     read_checkpoint_index,
-    verify_checkpoint,
 )
-from .utils import Prompt, batchify, empty_cache, mean_distances_to_knn, print
+from .utils import (
+    Prompt,
+    batchify,
+    empty_cache,
+    mean_distances_to_knn,
+    print,
+    prompt_select,
+)
 
 
 def get_model_class(
@@ -85,19 +90,6 @@ class ARAParameters:
 ModuleIO: TypeAlias = list[dict[str, dict[int, tuple[Tensor, Tensor]]]]
 
 
-# Element sizes of the floating point dtypes that appear in safetensors headers.
-# Anything absent from this table is an integer or boolean tensor, whose size does
-# not change when the model is reloaded in another precision.
-FLOAT_DTYPE_SIZES = {
-    "F64": 8,
-    "F32": 4,
-    "F16": 2,
-    "BF16": 2,
-    "F8_E4M3": 1,
-    "F8_E5M2": 1,
-}
-
-
 def directory_size(directory: Path) -> int:
     return sum(path.stat().st_size for path in directory.rglob("*") if path.is_file())
 
@@ -107,7 +99,6 @@ class Model:
     tokenizer: PreTrainedTokenizerBase
     peft_config: LoraConfig
     source_index: CheckpointIndex
-    check_captures: Captures
 
     def __init__(self, settings: Settings):
         self.settings = settings
@@ -142,20 +133,6 @@ class Model:
         if self.settings.evaluate_model is not None:
             self.trusted_models[settings.evaluate_model] = settings.trust_remote_code
 
-        # Asking for loading info when the source is a PEFT adapter raises, because
-        # load_adapter() returns None where from_pretrained() expects an object to
-        # call to_dict() on. The exception would be caught by the dtype handler below,
-        # retried once per configured dtype at the cost of a full load each time, and
-        # finally reported as a dtype problem. This is the same test transformers
-        # itself uses to decide whether to take the adapter path, and anything it
-        # raises (a bad model ID, most importantly) means "not an adapter".
-        try:
-            adapter_source = find_adapter_config_file(settings.model) is not None
-        except Exception:
-            adapter_source = False
-
-        loading_info = None
-
         for dtype in settings.dtypes:
             print(f"* Trying dtype [bold]{dtype}[/]...")
 
@@ -168,20 +145,14 @@ class Model:
                 if quantization_config is not None:
                     extra_kwargs["quantization_config"] = quantization_config
 
-                loaded = get_model_class(settings.model).from_pretrained(
+                self.model = get_model_class(settings.model).from_pretrained(
                     settings.model,
                     dtype=dtype,
                     device_map=settings.device_map,
                     max_memory=self.max_memory,
                     trust_remote_code=self.trusted_models.get(settings.model),
-                    output_loading_info=not adapter_source,
                     **extra_kwargs,
                 )
-
-                if adapter_source:
-                    self.model = loaded
-                else:
-                    self.model, loading_info = loaded
 
                 # If we reach this point and the model requires trust_remote_code,
                 # either the user accepted, or settings.trust_remote_code is True.
@@ -214,37 +185,33 @@ class Model:
         if self.model is None:
             raise Exception("Failed to load model with all configured dtypes.")
 
-        # The progress bars the loader leaves behind are only torn down when their
-        # objects are collected, and they erase themselves relative to wherever the
-        # cursor was when that happens. Anything that runs here shifts the moment of
-        # collection, which leaves the bars stranded on screen. Collecting now pins it
-        # to a point where the terminal is still where the loader left it.
+        # Collect the loader's progress bars now; collected later, they erase
+        # themselves relative to wherever the cursor has moved to.
         empty_cache()
 
-        self._prepare_tensor_check(loading_info)
+        self._prepare_tensor_check()
 
-        trial_target = self._trial_save_target()
-        if trial_target is not None and not self._announce_trial_save(trial_target):
-            trial_target = None
+        preflight_target = self._preflight_save_target()
+        if preflight_target is not None and not self._announce_preflight_save(
+            preflight_target
+        ):
+            preflight_target = None
 
-        if trial_target == "loaded":
-            # Still the bare model here. Once _apply_lora has run, the targeted leaf
-            # modules are replaced in place by LoRA wrappers, and saving it would write
-            # adapter tensors rather than the model the save path produces.
+        if preflight_target == "loaded":
+            # Before _apply_lora: a LoRA-wrapped tree serializes adapter names,
+            # not the model's.
             assert isinstance(self.model, PreTrainedModel)
-            self._trial_save(self.model)
+            self._preflight_save(self.model)
 
         if not settings.use_ara or settings.use_ara_lora:
             self._apply_lora()
 
-        # Only this configuration saves something that does not already exist:
-        # get_merged_model() reloads the base model in full precision and merges into
-        # that, discarding the quantized one. Serializing anything else here would be
-        # testing a path the run never takes.
-        if trial_target == "merged":
+        # The save on this path writes get_merged_model()'s product, not anything
+        # already in memory.
+        if preflight_target == "merged":
             merged_model = self.get_merged_model()
             try:
-                self._trial_save(merged_model)
+                self._preflight_save(merged_model)
             finally:
                 del merged_model
                 empty_cache()
@@ -263,29 +230,27 @@ class Model:
         for component, count in all_components.items():
             print(f"  * [bold]{component}[/]: [bold]{count}[/] modules total")
 
-    def _prepare_tensor_check(self, loading_info: dict[str, Any] | None):
+    def _prepare_tensor_check(self):
         """
-        Reads the tensor names of the source checkpoint, and records what the model
-        says about them, so that anything saved later can be compared against it.
-
-        Everything here is best effort. A source that cannot be resolved or read means
-        only that saves cannot be verified, which must not stop the run.
+        Reads the source checkpoint's tensor names, so saves can be compared to them.
+        Best effort: a source that cannot be read must not stop the run.
         """
         self.source_index = {}
-        self.check_captures = Captures()
 
-        if loading_info is None:
+        # save_pretrained on a PEFT-loaded model (full weights beside the adapter
+        # config included) writes only the adapter, so there is no model save to
+        # verify.
+        if self.model._hf_peft_config_loaded:
             print(
-                "* Saved models cannot be verified (the source is a LoRA adapter)"
+                "* Saved models cannot be verified (this source loads as a PEFT "
+                "adapter, so saving writes the adapter, not the model)"
             )
             return
 
         try:
             source_directory = Path(self.settings.model)
             if not source_directory.is_dir():
-                # Resolved after the load rather than before it. Before it, only the
-                # tokenizer has been fetched, so the snapshot holds configuration files
-                # and no weights to compare against.
+                # Only after the load is the cached snapshot known to hold weights.
                 source_directory = Path(
                     huggingface_hub.snapshot_download(
                         self.settings.model,
@@ -294,36 +259,26 @@ class Model:
                 )
 
             self.source_index = read_checkpoint_index(source_directory)
-            self.check_captures = capture_state(
-                self.model,
-                loading_info["missing_keys"],
-                loading_info["unexpected_keys"],
-            )
         except Exception as error:
             self.source_index = {}
             print(f"* Saved models cannot be verified ({error})")
             return
 
         if not self.source_index:
-            print(
-                "* Saved models cannot be verified (the source has no safetensors)"
-            )
+            print("* Saved models cannot be verified (the source has no safetensors)")
 
-    def _trial_save_target(self) -> str | None:
+    def _preflight_save_target(self) -> str | None:
         """
-        Decides whether to save the model once before optimization starts, and which
-        object the eventual save would write.
-
         Returns "loaded" for the model as loaded, "merged" for what get_merged_model()
-        produces, or None to skip the trial.
+        produces, or None to skip the preflight save.
         """
         settings = self.settings
 
         if not settings.preflight_save_check or not self.source_index:
             return None
 
-        # An ARA-LoRA run writes an adapter, whose tensor names bear no relation to the
-        # source checkpoint, so a full-model trial would predict nothing about it.
+        # An ARA-LoRA run writes an adapter; a full-model preflight save would
+        # predict nothing about it.
         if settings.use_ara and settings.use_ara_lora:
             return None
 
@@ -331,10 +286,8 @@ class Model:
         if settings.evaluate_model is not None:
             return None
 
-        # ARA edits full weights and cannot run against a quantized model at all, which
-        # is the reason use_ara_lora exists. Trialling this would serialize the
-        # bitsandbytes model and reject it over quantization state names, blaming the
-        # environment for a configuration problem abliteration reports properly.
+        # A preflight save here would flag the bitsandbytes model's quantization
+        # state as differences, on a configuration ARA rejects on its own anyway.
         if settings.use_ara and settings.quantization != QuantizationMethod.NONE:
             return None
 
@@ -344,25 +297,19 @@ class Model:
 
         return "merged"
 
-    def _trial_directory(self) -> Path:
+    def _preflight_save_directory(self) -> Path:
         return (
-            Path(self.settings.preflight_directory)
+            Path(self.settings.scratch_directory)
             / f"heretic-preflight-{Path(self.settings.model).name}"
         )
 
     def _source_payload_size(self) -> int:
-        return sum(nbytes for _, _, nbytes in self.source_index.values())
+        return sum(nbytes for _, nbytes in self.source_index.values())
 
-    def _trial_save_size(self, model: PreTrainedModel | PeftModel) -> int:
-        """
-        Bytes the trial save is expected to write, over-reported rather than under.
-
-        Neither term is enough on its own. On the MXFP4 quantized path the expert
-        weights are deregistered as the checkpoint is read and only restored inside
-        save_pretrained, so state_dict() accounts for about a quarter of what is
-        actually written. On the dequantize path the source checkpoint accounts for
-        about a third of it, because the weights are expanded on the way out.
-        """
+    def _preflight_save_size(self, model: PreTrainedModel | PeftModel) -> int:
+        # Each term alone under-reports: state_dict misses MXFP4 expert weights
+        # (deregistered until save_pretrained restores them), and the source payload
+        # misses the expansion of a dequantized write.
         state_dict_size = sum(
             tensor.numel() * tensor.element_size()
             for tensor in model.state_dict().values()
@@ -370,67 +317,26 @@ class Model:
 
         return int(max(state_dict_size, self._source_payload_size()) * 1.05)
 
-    def _full_precision_size(self) -> int:
+    def _announce_preflight_save(self, target: str) -> bool:
         """
-        Bytes the base model occupies once it is reloaded in full precision.
-
-        Scaled per tensor rather than from one representative dtype, because real
-        checkpoints are mixed: gpt-oss is 363 BF16 tensors and 96 U8 ones, and treating
-        either as the whole is wrong by a factor of four in one direction or the other.
+        Explains the preflight save; returns False if it should not run after all.
         """
-        target_size = self.model.dtype.itemsize
-        total = 0
-
-        for dtype, _, nbytes in self.source_index.values():
-            source_size = FLOAT_DTYPE_SIZES.get(dtype)
-            total += (nbytes * target_size // source_size) if source_size else nbytes
-
-        return total
-
-    def _abort_run(self, message: str):
-        print()
-        print(f"[red]{message}[/]")
-        print(
-            "Pass [bold]--no-preflight-save-check[/] to skip this check, or press "
-            "Ctrl+C during the countdown to skip it for this run only."
-        )
-        raise Exception(message)
-
-    def _announce_trial_save(self, target: str) -> bool:
-        """
-        Explains the trial save and offers a moment to skip it.
-        Returns False if it should not run after all.
-        """
-        # Free, so it happens before anything that costs time or can end the run. An
-        # architecture Heretic cannot navigate must fail as that, rather than after a
-        # countdown and a full serialization that would read as a verdict on saving.
+        # An unsupported architecture must fail here, not after a countdown and a
+        # full serialization.
         self.get_layers()
 
         print()
 
         if target == "merged":
-            # The memory goes on building the object, so there is nothing to measure
-            # yet and the requirement has to come from the source checkpoint. A full
-            # disk raises and can be explained; running out of RAM gets the process
-            # killed, so this one is checked rather than only disclosed.
-            required_ram = self._full_precision_size()
-            available_ram = virtual_memory().available
-
+            # Warned rather than guarded, matching the save-time merge prompt.
             print(
-                "Merging into a quantized model reloads it in full precision first, "
-                f"which needs about [bold]{required_ram / 1024**3:.1f} GB[/] of RAM."
+                "Merging into a quantized model reloads it in full precision on "
+                "CPU first. [yellow]This can lead to system freezes if you run "
+                "out of memory.[/]"
             )
-
-            if available_ram < required_ram:
-                self._abort_run(
-                    "Not enough system RAM to check that this model can be saved: "
-                    f"{required_ram / 1024**3:.1f} GB needed, "
-                    f"{available_ram / 1024**3:.1f} GB available."
-                )
-
-            estimated_size = required_ram
+            estimated_size = self._source_payload_size()
         else:
-            estimated_size = self._trial_save_size(self.model)
+            estimated_size = self._preflight_save_size(self.model)
 
         print(
             "Checking that this environment can save the model correctly, before "
@@ -438,7 +344,8 @@ class Model:
         )
         print(
             f"This writes about [bold]{estimated_size / 1024**3:.1f} GB[/] to "
-            f"[bold]{self._trial_directory()}[/], and removes it again afterwards."
+            f"[bold]{self._preflight_save_directory()}[/], and removes it again "
+            "afterwards."
         )
         print(
             "Starting in 10 seconds. Press Ctrl+C to skip it, or pass "
@@ -453,60 +360,88 @@ class Model:
 
         return True
 
-    def _trial_save(self, model: PreTrainedModel):
-        directory = self._trial_directory()
+    def _confirm_continue(self, message: str, continue_title: str) -> bool:
+        # questionary turns Ctrl+C into None and a closed input raises EOFError;
+        # anything but an explicit continue must stop.
+        try:
+            choice = prompt_select(
+                message,
+                [
+                    Choice(title="Stop (recommended)", value="stop"),
+                    Choice(title=continue_title, value="continue"),
+                ],
+            )
+        except (KeyboardInterrupt, EOFError):
+            choice = None
 
-        # Removed before the free space is measured, not after, so that a retry counts
-        # the space a previous attempt's leftovers are occupying as available.
+        return choice == "continue"
+
+    def _preflight_save(self, model: PreTrainedModel):
+        directory = self._preflight_save_directory()
+
+        # A stale artifact from an earlier stopped run must not pollute the
+        # comparison; save_pretrained does not clear a directory.
         if directory.exists():
             shutil.rmtree(directory)
 
-        required_space = self._trial_save_size(model)
-        available_space = shutil.disk_usage(self.settings.preflight_directory).free
-
-        if available_space < required_space:
-            self._abort_run(
-                "Not enough free disk space to check that this model can be saved: "
-                f"{required_space / 1024**3:.1f} GB needed in "
-                f"{self.settings.preflight_directory}, "
-                f"{available_space / 1024**3:.1f} GB available."
-            )
-
         try:
             model.save_pretrained(directory)
-            verify_checkpoint(
-                directory,
-                self.source_index,
-                self.check_captures,
-                context="preflight",
-            )
-        except TensorCheckError as error:
-            # Model.__init__ is constructed outside any handler, so the diagnosis is
-            # printed here rather than left to the exception: raised from here it would
-            # reach the user as a traceback, or as nothing at all when the failure
-            # happened while handling a Ctrl+C. What propagates is a one-line summary,
-            # so the traceback does not repeat everything just printed.
-            print()
-            print(f"[red]{error}[/]")
-            print(
-                f"It occupies {directory_size(directory) / 1024**3:.1f} GB."
-            )
-            raise TensorCheckError(
-                "This environment does not save the model correctly (see above)."
-            ) from None
+            result = compare_checkpoint(directory, self.source_index)
         except Exception as error:
+            # Transformers can swallow a Ctrl+C and raise something else; re-raise
+            # so main() sees the interrupt instead of this prompting a user who
+            # just aborted.
+            if isinstance(error.__context__, KeyboardInterrupt):
+                raise
             print()
-            print(
-                f"[red]This environment cannot save the model: {error}[/]"
+            print(f"[red]This environment cannot save the model: {error}[/]")
+            result = None
+
+        if result is not None and result.verdict == Verdict.CLEAN:
+            shutil.rmtree(directory, ignore_errors=True)
+            print("* This environment saves the model correctly")
+            return
+
+        # Nothing catches exceptions from Model.__init__, so the diagnosis is
+        # printed here and only a one-line summary propagates into the traceback.
+        if result is not None:
+            print()
+            print(f"[red]{result.describe(CheckSite.PREFLIGHT, directory)}[/]")
+            print(f"It occupies {directory_size(directory) / 1024**3:.1f} GB.")
+
+        cannot_save = result is None or result.verdict == Verdict.NO_WEIGHTS
+
+        if cannot_save:
+            continue_run = self._confirm_continue(
+                "Saving will fail the same way at the end of the run. Continue anyway?",
+                "Continue without a working save",
             )
+        else:
+            continue_run = self._confirm_continue(
+                "The optimized model would be saved by this same environment. "
+                "Continue anyway?",
+                "Continue anyway",
+            )
+
+        if continue_run:
+            shutil.rmtree(directory, ignore_errors=True)
+            return
+
+        if result is None:
             print(
                 f"The incomplete save has been left at [bold]{directory}[/], "
                 f"occupying {directory_size(directory) / 1024**3:.1f} GB."
             )
-            raise
 
-        shutil.rmtree(directory, ignore_errors=True)
-        print("* This environment saves the model correctly")
+        if cannot_save:
+            raise Exception(
+                "This environment does not save the model correctly (see above)."
+            )
+
+        raise Exception(
+            "Run stopped: the preflight save differs from the source checkpoint "
+            "(see above)."
+        )
 
     def _apply_lora(self):
         # Guard against calling this method at the wrong time.

--- a/src/heretic/model.py
+++ b/src/heretic/model.py
@@ -2,16 +2,21 @@
 # Copyright (C) 2025-2026  Philipp Emanuel Weidmann <pew@worldwidemann.com> + contributors
 
 import math
+import shutil
+import time
 from contextlib import suppress
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Callable, Type, TypeAlias, cast
 
 import bitsandbytes as bnb
+import huggingface_hub
 import torch
 import torch.linalg as LA
 import torch.nn.functional as F
 from peft import LoraConfig, PeftModel, get_peft_model
 from peft.tuners.lora.layer import Linear
+from psutil import virtual_memory
 from torch import FloatTensor, LongTensor, Tensor
 from torch.nn import Module, ModuleList
 from torch.optim import LBFGS
@@ -30,8 +35,17 @@ from transformers import (
 from transformers.generation import (
     GenerateDecoderOnlyOutput,  # ty:ignore[possibly-missing-import]
 )
+from transformers.utils.peft_utils import find_adapter_config_file
 
 from .config import QuantizationMethod, RowNormalization, Settings
+from .tensor_check import (
+    Captures,
+    CheckpointIndex,
+    TensorCheckError,
+    capture_state,
+    read_checkpoint_index,
+    verify_checkpoint,
+)
 from .utils import Prompt, batchify, empty_cache, mean_distances_to_knn, print
 
 
@@ -71,10 +85,29 @@ class ARAParameters:
 ModuleIO: TypeAlias = list[dict[str, dict[int, tuple[Tensor, Tensor]]]]
 
 
+# Element sizes of the floating point dtypes that appear in safetensors headers.
+# Anything absent from this table is an integer or boolean tensor, whose size does
+# not change when the model is reloaded in another precision.
+FLOAT_DTYPE_SIZES = {
+    "F64": 8,
+    "F32": 4,
+    "F16": 2,
+    "BF16": 2,
+    "F8_E4M3": 1,
+    "F8_E5M2": 1,
+}
+
+
+def directory_size(directory: Path) -> int:
+    return sum(path.stat().st_size for path in directory.rglob("*") if path.is_file())
+
+
 class Model:
     model: PreTrainedModel | PeftModel
     tokenizer: PreTrainedTokenizerBase
     peft_config: LoraConfig
+    source_index: CheckpointIndex
+    check_captures: Captures
 
     def __init__(self, settings: Settings):
         self.settings = settings
@@ -109,6 +142,20 @@ class Model:
         if self.settings.evaluate_model is not None:
             self.trusted_models[settings.evaluate_model] = settings.trust_remote_code
 
+        # Asking for loading info when the source is a PEFT adapter raises, because
+        # load_adapter() returns None where from_pretrained() expects an object to
+        # call to_dict() on. The exception would be caught by the dtype handler below,
+        # retried once per configured dtype at the cost of a full load each time, and
+        # finally reported as a dtype problem. This is the same test transformers
+        # itself uses to decide whether to take the adapter path, and anything it
+        # raises (a bad model ID, most importantly) means "not an adapter".
+        try:
+            adapter_source = find_adapter_config_file(settings.model) is not None
+        except Exception:
+            adapter_source = False
+
+        loading_info = None
+
         for dtype in settings.dtypes:
             print(f"* Trying dtype [bold]{dtype}[/]...")
 
@@ -121,14 +168,20 @@ class Model:
                 if quantization_config is not None:
                     extra_kwargs["quantization_config"] = quantization_config
 
-                self.model = get_model_class(settings.model).from_pretrained(
+                loaded = get_model_class(settings.model).from_pretrained(
                     settings.model,
                     dtype=dtype,
                     device_map=settings.device_map,
                     max_memory=self.max_memory,
                     trust_remote_code=self.trusted_models.get(settings.model),
+                    output_loading_info=not adapter_source,
                     **extra_kwargs,
                 )
+
+                if adapter_source:
+                    self.model = loaded
+                else:
+                    self.model, loading_info = loaded
 
                 # If we reach this point and the model requires trust_remote_code,
                 # either the user accepted, or settings.trust_remote_code is True.
@@ -161,8 +214,40 @@ class Model:
         if self.model is None:
             raise Exception("Failed to load model with all configured dtypes.")
 
+        # The progress bars the loader leaves behind are only torn down when their
+        # objects are collected, and they erase themselves relative to wherever the
+        # cursor was when that happens. Anything that runs here shifts the moment of
+        # collection, which leaves the bars stranded on screen. Collecting now pins it
+        # to a point where the terminal is still where the loader left it.
+        empty_cache()
+
+        self._prepare_tensor_check(loading_info)
+
+        trial_target = self._trial_save_target()
+        if trial_target is not None and not self._announce_trial_save(trial_target):
+            trial_target = None
+
+        if trial_target == "loaded":
+            # Still the bare model here. Once _apply_lora has run, the targeted leaf
+            # modules are replaced in place by LoRA wrappers, and saving it would write
+            # adapter tensors rather than the model the save path produces.
+            assert isinstance(self.model, PreTrainedModel)
+            self._trial_save(self.model)
+
         if not settings.use_ara or settings.use_ara_lora:
             self._apply_lora()
+
+        # Only this configuration saves something that does not already exist:
+        # get_merged_model() reloads the base model in full precision and merges into
+        # that, discarding the quantized one. Serializing anything else here would be
+        # testing a path the run never takes.
+        if trial_target == "merged":
+            merged_model = self.get_merged_model()
+            try:
+                self._trial_save(merged_model)
+            finally:
+                del merged_model
+                empty_cache()
 
         # LoRA B matrices are initialized to zero by default in PEFT,
         # so we don't need to do anything manually.
@@ -177,6 +262,251 @@ class Model:
                 all_components[component] += len(modules)
         for component, count in all_components.items():
             print(f"  * [bold]{component}[/]: [bold]{count}[/] modules total")
+
+    def _prepare_tensor_check(self, loading_info: dict[str, Any] | None):
+        """
+        Reads the tensor names of the source checkpoint, and records what the model
+        says about them, so that anything saved later can be compared against it.
+
+        Everything here is best effort. A source that cannot be resolved or read means
+        only that saves cannot be verified, which must not stop the run.
+        """
+        self.source_index = {}
+        self.check_captures = Captures()
+
+        if loading_info is None:
+            print(
+                "* Saved models cannot be verified (the source is a LoRA adapter)"
+            )
+            return
+
+        try:
+            source_directory = Path(self.settings.model)
+            if not source_directory.is_dir():
+                # Resolved after the load rather than before it. Before it, only the
+                # tokenizer has been fetched, so the snapshot holds configuration files
+                # and no weights to compare against.
+                source_directory = Path(
+                    huggingface_hub.snapshot_download(
+                        self.settings.model,
+                        local_files_only=True,
+                    )
+                )
+
+            self.source_index = read_checkpoint_index(source_directory)
+            self.check_captures = capture_state(
+                self.model,
+                loading_info["missing_keys"],
+                loading_info["unexpected_keys"],
+            )
+        except Exception as error:
+            self.source_index = {}
+            print(f"* Saved models cannot be verified ({error})")
+            return
+
+        if not self.source_index:
+            print(
+                "* Saved models cannot be verified (the source has no safetensors)"
+            )
+
+    def _trial_save_target(self) -> str | None:
+        """
+        Decides whether to save the model once before optimization starts, and which
+        object the eventual save would write.
+
+        Returns "loaded" for the model as loaded, "merged" for what get_merged_model()
+        produces, or None to skip the trial.
+        """
+        settings = self.settings
+
+        if not settings.preflight_save_check or not self.source_index:
+            return None
+
+        # An ARA-LoRA run writes an adapter, whose tensor names bear no relation to the
+        # source checkpoint, so a full-model trial would predict nothing about it.
+        if settings.use_ara and settings.use_ara_lora:
+            return None
+
+        # This run returns before it reaches a save.
+        if settings.evaluate_model is not None:
+            return None
+
+        # ARA edits full weights and cannot run against a quantized model at all, which
+        # is the reason use_ara_lora exists. Trialling this would serialize the
+        # bitsandbytes model and reject it over quantization state names, blaming the
+        # environment for a configuration problem abliteration reports properly.
+        if settings.use_ara and settings.quantization != QuantizationMethod.NONE:
+            return None
+
+        # Mirrors the dispatch of the save itself, which selects on use_ara.
+        if settings.use_ara or settings.quantization == QuantizationMethod.NONE:
+            return "loaded"
+
+        return "merged"
+
+    def _trial_directory(self) -> Path:
+        return (
+            Path(self.settings.preflight_directory)
+            / f"heretic-preflight-{Path(self.settings.model).name}"
+        )
+
+    def _source_payload_size(self) -> int:
+        return sum(nbytes for _, _, nbytes in self.source_index.values())
+
+    def _trial_save_size(self, model: PreTrainedModel | PeftModel) -> int:
+        """
+        Bytes the trial save is expected to write, over-reported rather than under.
+
+        Neither term is enough on its own. On the MXFP4 quantized path the expert
+        weights are deregistered as the checkpoint is read and only restored inside
+        save_pretrained, so state_dict() accounts for about a quarter of what is
+        actually written. On the dequantize path the source checkpoint accounts for
+        about a third of it, because the weights are expanded on the way out.
+        """
+        state_dict_size = sum(
+            tensor.numel() * tensor.element_size()
+            for tensor in model.state_dict().values()
+        )
+
+        return int(max(state_dict_size, self._source_payload_size()) * 1.05)
+
+    def _full_precision_size(self) -> int:
+        """
+        Bytes the base model occupies once it is reloaded in full precision.
+
+        Scaled per tensor rather than from one representative dtype, because real
+        checkpoints are mixed: gpt-oss is 363 BF16 tensors and 96 U8 ones, and treating
+        either as the whole is wrong by a factor of four in one direction or the other.
+        """
+        target_size = self.model.dtype.itemsize
+        total = 0
+
+        for dtype, _, nbytes in self.source_index.values():
+            source_size = FLOAT_DTYPE_SIZES.get(dtype)
+            total += (nbytes * target_size // source_size) if source_size else nbytes
+
+        return total
+
+    def _abort_run(self, message: str):
+        print()
+        print(f"[red]{message}[/]")
+        print(
+            "Pass [bold]--no-preflight-save-check[/] to skip this check, or press "
+            "Ctrl+C during the countdown to skip it for this run only."
+        )
+        raise Exception(message)
+
+    def _announce_trial_save(self, target: str) -> bool:
+        """
+        Explains the trial save and offers a moment to skip it.
+        Returns False if it should not run after all.
+        """
+        # Free, so it happens before anything that costs time or can end the run. An
+        # architecture Heretic cannot navigate must fail as that, rather than after a
+        # countdown and a full serialization that would read as a verdict on saving.
+        self.get_layers()
+
+        print()
+
+        if target == "merged":
+            # The memory goes on building the object, so there is nothing to measure
+            # yet and the requirement has to come from the source checkpoint. A full
+            # disk raises and can be explained; running out of RAM gets the process
+            # killed, so this one is checked rather than only disclosed.
+            required_ram = self._full_precision_size()
+            available_ram = virtual_memory().available
+
+            print(
+                "Merging into a quantized model reloads it in full precision first, "
+                f"which needs about [bold]{required_ram / 1024**3:.1f} GB[/] of RAM."
+            )
+
+            if available_ram < required_ram:
+                self._abort_run(
+                    "Not enough system RAM to check that this model can be saved: "
+                    f"{required_ram / 1024**3:.1f} GB needed, "
+                    f"{available_ram / 1024**3:.1f} GB available."
+                )
+
+            estimated_size = required_ram
+        else:
+            estimated_size = self._trial_save_size(self.model)
+
+        print(
+            "Checking that this environment can save the model correctly, before "
+            "spending any time on optimization."
+        )
+        print(
+            f"This writes about [bold]{estimated_size / 1024**3:.1f} GB[/] to "
+            f"[bold]{self._trial_directory()}[/], and removes it again afterwards."
+        )
+        print(
+            "Starting in 10 seconds. Press Ctrl+C to skip it, or pass "
+            "[bold]--no-preflight-save-check[/] to skip it in future runs."
+        )
+
+        try:
+            time.sleep(10)
+        except KeyboardInterrupt:
+            print("* Save check skipped")
+            return False
+
+        return True
+
+    def _trial_save(self, model: PreTrainedModel):
+        directory = self._trial_directory()
+
+        # Removed before the free space is measured, not after, so that a retry counts
+        # the space a previous attempt's leftovers are occupying as available.
+        if directory.exists():
+            shutil.rmtree(directory)
+
+        required_space = self._trial_save_size(model)
+        available_space = shutil.disk_usage(self.settings.preflight_directory).free
+
+        if available_space < required_space:
+            self._abort_run(
+                "Not enough free disk space to check that this model can be saved: "
+                f"{required_space / 1024**3:.1f} GB needed in "
+                f"{self.settings.preflight_directory}, "
+                f"{available_space / 1024**3:.1f} GB available."
+            )
+
+        try:
+            model.save_pretrained(directory)
+            verify_checkpoint(
+                directory,
+                self.source_index,
+                self.check_captures,
+                context="preflight",
+            )
+        except TensorCheckError as error:
+            # Model.__init__ is constructed outside any handler, so the diagnosis is
+            # printed here rather than left to the exception: raised from here it would
+            # reach the user as a traceback, or as nothing at all when the failure
+            # happened while handling a Ctrl+C. What propagates is a one-line summary,
+            # so the traceback does not repeat everything just printed.
+            print()
+            print(f"[red]{error}[/]")
+            print(
+                f"It occupies {directory_size(directory) / 1024**3:.1f} GB."
+            )
+            raise TensorCheckError(
+                "This environment does not save the model correctly (see above)."
+            ) from None
+        except Exception as error:
+            print()
+            print(
+                f"[red]This environment cannot save the model: {error}[/]"
+            )
+            print(
+                f"The incomplete save has been left at [bold]{directory}[/], "
+                f"occupying {directory_size(directory) / 1024**3:.1f} GB."
+            )
+            raise
+
+        shutil.rmtree(directory, ignore_errors=True)
+        print("* This environment saves the model correctly")
 
     def _apply_lora(self):
         # Guard against calling this method at the wrong time.

--- a/src/heretic/tensor_check.py
+++ b/src/heretic/tensor_check.py
@@ -1,180 +1,48 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # Copyright (C) 2025-2026  Philipp Emanuel Weidmann <pew@worldwidemann.com> + contributors
 
-import json
-from dataclasses import dataclass, field
-from enum import Enum
 from pathlib import Path
-from typing import Mapping
 
-from huggingface_hub import parse_local_safetensors_file_metadata
-from huggingface_hub.constants import SAFETENSORS_INDEX_FILE, SAFETENSORS_SINGLE_FILE
+from huggingface_hub import get_local_safetensors_metadata, snapshot_download
 from rich.markup import escape
 
-# Name -> (shape, nbytes). nbytes is carried for the preflight sizing in model.py.
-# The index deliberately carries no dtype: a correct transformers 5.3.0 save of
-# gpt-oss widens 48 expert bias dtypes, so comparing dtype would flag the very
-# model this check exists to protect.
-CheckpointIndex = dict[str, tuple[tuple[int, ...], int]]
+from .utils import print
 
 
-class Verdict(str, Enum):
-    CLEAN = "clean"
-    DIFFERS = "differs"
-    NO_WEIGHTS = "no_weights"
-    UNAVAILABLE = "unavailable"
-
-
-class CheckSite(str, Enum):
-    PREFLIGHT = "preflight"
-    POST_SAVE = "post_save"
-    UPLOAD = "upload"
-
-
-@dataclass
-class CheckResult:
-    verdict: Verdict
-    reason: str = ""
-
-    source_count: int = 0
-    written_count: int = 0
-
-    # Names in the source and not in the artifact, and the reverse, both sorted.
-    absent: list[str] = field(default_factory=list)
-    extra: list[str] = field(default_factory=list)
-    shape_mismatches: list[tuple[str, tuple[int, ...], tuple[int, ...]]] = field(
-        default_factory=list
-    )
-
-    def describe(self, site: CheckSite, written_directory: Path) -> str:
-        if self.verdict == Verdict.NO_WEIGHTS:
-            lines = [
-                f"{self.reason.capitalize()}. Configuration files may exist, "
-                "but no weights do.",
-            ]
-        else:
-            lines = [
-                "Heretic rewrites tensor values and never renames, so a correct "
-                "save writes exactly the source checkpoint's names and shapes; "
-                "this save did not.",
-            ]
-
-        lines.append(
-            f"  source names: {self.source_count}, written names: {self.written_count}"
-        )
-
-        shape_samples = [
-            f"{name}: {source_shape} -> {written_shape}"
-            for name, source_shape, written_shape in self.shape_mismatches
-        ]
-        for label, entries in (
-            ("in the source checkpoint but not in the saved model", self.absent),
-            ("in the saved model but not in the source checkpoint", self.extra),
-            ("written under the same name with a different shape", shape_samples),
-        ):
-            if entries:
-                lines.append(f"  {label}: {len(entries)}")
-                lines.extend(f"    {entry}" for entry in entries[:5])
-
-        lines.append(
-            "  This may indicate a serialization bug in transformers, or a benign "
-            "difference intended by transformers; either way, it is not anything "
-            "abliteration did."
-        )
-
-        if site == CheckSite.PREFLIGHT:
-            lines.append(
-                "  This preflight save cost no optimization time. It is at "
-                f"{written_directory}: kept if the run stops here, removed if "
-                "you choose to continue."
-            )
-        elif site == CheckSite.POST_SAVE:
-            lines.append(
-                f"  The model at {written_directory} was already written when "
-                "this was detected. Saving is destructive in place, so if that "
-                "folder held an earlier model, it is gone."
-            )
-        else:
-            lines.append(
-                f"  Nothing has been uploaded. The model is at {written_directory}."
-            )
-
-        # Heretic's printer parses square brackets as markup, so an unescaped
-        # tensor-name list would be silently swallowed.
-        return escape("\n".join(lines))
-
-
-def resolve_shards(directory: Path) -> list[Path]:
-    # Globbing over-collects: Mistral-7B-Instruct-v0.3 ships a top-level
-    # consolidated.safetensors holding 291 tensors in a naming transformers never
-    # reads, and a reused output directory can hold a previous run's adapter or shards.
-    #
-    # save_pretrained only deletes files matching (.*?)-\d{5}-of-\d{5}, so a stale
-    # index survives an unsharded save and a stale model.safetensors survives a
-    # sharded one. Filtering index entries by existence resolves both directions.
-    index_path = directory / SAFETENSORS_INDEX_FILE
-    if index_path.is_file():
-        try:
-            with index_path.open("r", encoding="utf-8") as file:
-                weight_map = json.load(file)["weight_map"]
-            names = {str(shard) for shard in weight_map.values()}
-        except Exception:
-            names = set()
-
-        shards = sorted(
-            {directory / name for name in names if (directory / name).is_file()},
-            key=lambda path: path.name,
-        )
-        if shards:
-            return shards
-
-    single_file = directory / SAFETENSORS_SINGLE_FILE
-    return [single_file] if single_file.is_file() else []
-
-
-def read_checkpoint_index(directory: Path) -> CheckpointIndex:
+def tensor_shapes(location: str) -> dict[str, tuple[int, ...]]:
+    try:
+        if not Path(location).is_dir():
+            location = snapshot_download(location, local_files_only=True)
+        metadata = get_local_safetensors_metadata(location)
+    except Exception:
+        return {}
     return {
-        name: (tuple(info.shape), info.data_offsets[1] - info.data_offsets[0])
-        for shard in resolve_shards(directory)
-        for name, info in parse_local_safetensors_file_metadata(shard).tensors.items()
+        name: tuple(info.shape)
+        for file in metadata.files_metadata.values()
+        for name, info in file.tensors.items()
     }
 
 
-def compare_checkpoint(
-    written_directory: Path,
-    source_index: Mapping[str, tuple[tuple[int, ...], int]],
-) -> CheckResult:
-    if not source_index:
-        return CheckResult(
-            verdict=Verdict.UNAVAILABLE,
-            reason="no source checkpoint index to compare against",
-        )
-
-    written_index = read_checkpoint_index(written_directory)
-    result = CheckResult(
-        verdict=Verdict.CLEAN,
-        source_count=len(source_index),
-        written_count=len(written_index),
-    )
-
-    if not written_index:
-        result.verdict = Verdict.NO_WEIGHTS
-        result.reason = "no safetensors shards were written"
-        return result
-
-    source_names = set(source_index)
-    written_names = set(written_index)
-
-    result.absent = sorted(source_names - written_names)
-    result.extra = sorted(written_names - source_names)
-
-    result.shape_mismatches = [
-        (name, source_index[name][0], written_index[name][0])
-        for name in sorted(source_names & written_names)
-        if source_index[name][0] != written_index[name][0]
+def check_tensors(source: dict[str, tuple[int, ...]], directory: str) -> bool:
+    if not source:
+        return True
+    written = tensor_shapes(directory)
+    if not written:
+        print("[yellow]* Model has no readable safetensors weights[/]")
+        return False
+    names = sorted(set(source) | set(written))
+    differences = [
+        f"{name}: {source.get(name, 'absent')} -> {written.get(name, 'absent')}"
+        for name in names
+        if source.get(name) != written.get(name)
     ]
-
-    if result.absent or result.extra or result.shape_mismatches:
-        result.verdict = Verdict.DIFFERS
-
-    return result
+    if not differences:
+        print("* Model matches the source checkpoint")
+        return True
+    print(
+        f"[yellow]* Model differs from the source checkpoint at [bold]"
+        f"{len(differences)}[/] of {len(names)} names (source -> saved):[/]"
+    )
+    for difference in differences[:10]:
+        print(f"[yellow]    {escape(difference)}[/]")
+    return False

--- a/src/heretic/tensor_check.py
+++ b/src/heretic/tensor_check.py
@@ -2,119 +2,106 @@
 # Copyright (C) 2025-2026  Philipp Emanuel Weidmann <pew@worldwidemann.com> + contributors
 
 import json
-import re
-import struct
 from dataclasses import dataclass, field
+from enum import Enum
 from pathlib import Path
-from typing import Any, Callable, Iterable, Mapping, Sequence
+from typing import Mapping
 
+from huggingface_hub import parse_local_safetensors_file_metadata
+from huggingface_hub.constants import SAFETENSORS_INDEX_FILE, SAFETENSORS_SINGLE_FILE
 from rich.markup import escape
-from transformers.utils import SAFE_WEIGHTS_INDEX_NAME, SAFE_WEIGHTS_NAME
 
-from .utils import print
-
-
-class TensorCheckError(Exception):
-    pass
-
-
-@dataclass(frozen=True)
-class Entry:
-    id: str
-    title: str
-    mechanism: str
-
-
-# Every reason a written name may legitimately differ from the source checkpoint is
-# one of these, and each claims a specific name by naming the mechanism that entails
-# it. A name that no entry claims is unexplained, and unexplained means rejection.
-# Widening a comparison to accommodate a new case is never correct here; adding an
-# entry that states its mechanism is.
-WHITELIST = {
-    entry.id: entry
-    for entry in [
-        Entry(
-            "E1",
-            "reported unexpected",
-            "the loader reported this exact key in unexpected_keys, so the model never "
-            "registered it and the writer will not emit it",
-        ),
-        Entry(
-            "E2",
-            "suppressed unexpected",
-            "this name matches a pattern transformers applies to unexpected keys but "
-            "filters out of its own report, and it is not a live tensor",
-        ),
-        Entry(
-            "E3",
-            "newly initialized",
-            "the loader reported this exact key in missing_keys, so transformers "
-            "initialized it and the writer emits it although the source lacked it",
-        ),
-        Entry(
-            "E4",
-            "tie group",
-            "this name and that one tie to a single weight; safetensors forbids "
-            "aliasing, so which of them is written is transformers' choice",
-        ),
-        Entry(
-            "E5",
-            "converter fan-in",
-            "this absent source name lies under the module path of an un-locatable "
-            "unexpected_keys name, so it fuses into that parameter",
-        ),
-        Entry(
-            "E6",
-            "namespace un-locatable",
-            "this missing_keys name is in neither header, so it is a model-namespace "
-            "name that cannot be an expectation about checkpoint-namespace output",
-        ),
-        Entry(
-            "E7",
-            "declined reverse transpose",
-            "the model declares a converter whose source and target patterns are "
-            "identical and which transposes, and on save the reverse operation finds "
-            "the tensor already matching and declines to transpose back",
-        ),
-    ]
-}
-
-
-@dataclass
-class Claim:
-    name: str
-    entry: str
-    detail: str = ""
-
-
-# Name -> (dtype, shape, nbytes). The dtype is carried for the memory estimate in
-# model.py and is never compared: a correct transformers 5.3.0 save of gpt-oss widens
-# 48 expert bias tensors from BF16 to F32, so comparing dtype would reject the very
+# Name -> (shape, nbytes). nbytes is carried for the preflight sizing in model.py.
+# The index deliberately carries no dtype: a correct transformers 5.3.0 save of
+# gpt-oss widens 48 expert bias dtypes, so comparing dtype would flag the very
 # model this check exists to protect.
-CheckpointIndex = dict[str, tuple[str, tuple[int, ...], int]]
+CheckpointIndex = dict[str, tuple[tuple[int, ...], int]]
+
+
+class Verdict(str, Enum):
+    CLEAN = "clean"
+    DIFFERS = "differs"
+    NO_WEIGHTS = "no_weights"
+    UNAVAILABLE = "unavailable"
+
+
+class CheckSite(str, Enum):
+    PREFLIGHT = "preflight"
+    POST_SAVE = "post_save"
+    UPLOAD = "upload"
 
 
 @dataclass
 class CheckResult:
-    verdict: str
+    verdict: Verdict
     reason: str = ""
-    message: str = ""
 
     source_count: int = 0
     written_count: int = 0
 
-    unclaimed_absent: list[str] = field(default_factory=list)
-    unclaimed_extra: list[str] = field(default_factory=list)
-    unclaimed_shape: list[tuple[str, tuple[int, ...], tuple[int, ...]]] = field(
+    # Names in the source and not in the artifact, and the reverse, both sorted.
+    absent: list[str] = field(default_factory=list)
+    extra: list[str] = field(default_factory=list)
+    shape_mismatches: list[tuple[str, tuple[int, ...], tuple[int, ...]]] = field(
         default_factory=list
     )
-    claims: list[Claim] = field(default_factory=list)
 
-    def claims_by_entry(self) -> dict[str, int]:
-        counts: dict[str, int] = {}
-        for claim in self.claims:
-            counts[claim.entry] = counts.get(claim.entry, 0) + 1
-        return counts
+    def describe(self, site: CheckSite, written_directory: Path) -> str:
+        if self.verdict == Verdict.NO_WEIGHTS:
+            lines = [
+                f"{self.reason.capitalize()}. Configuration files may exist, "
+                "but no weights do.",
+            ]
+        else:
+            lines = [
+                "Heretic rewrites tensor values and never renames, so a correct "
+                "save writes exactly the source checkpoint's names and shapes; "
+                "this save did not.",
+            ]
+
+        lines.append(
+            f"  source names: {self.source_count}, written names: {self.written_count}"
+        )
+
+        shape_samples = [
+            f"{name}: {source_shape} -> {written_shape}"
+            for name, source_shape, written_shape in self.shape_mismatches
+        ]
+        for label, entries in (
+            ("in the source checkpoint but not in the saved model", self.absent),
+            ("in the saved model but not in the source checkpoint", self.extra),
+            ("written under the same name with a different shape", shape_samples),
+        ):
+            if entries:
+                lines.append(f"  {label}: {len(entries)}")
+                lines.extend(f"    {entry}" for entry in entries[:5])
+
+        lines.append(
+            "  This may indicate a serialization bug in transformers, or a benign "
+            "difference intended by transformers; either way, it is not anything "
+            "abliteration did."
+        )
+
+        if site == CheckSite.PREFLIGHT:
+            lines.append(
+                "  This preflight save cost no optimization time. It is at "
+                f"{written_directory}: kept if the run stops here, removed if "
+                "you choose to continue."
+            )
+        elif site == CheckSite.POST_SAVE:
+            lines.append(
+                f"  The model at {written_directory} was already written when "
+                "this was detected. Saving is destructive in place, so if that "
+                "folder held an earlier model, it is gone."
+            )
+        else:
+            lines.append(
+                f"  Nothing has been uploaded. The model is at {written_directory}."
+            )
+
+        # Heretic's printer parses square brackets as markup, so an unescaped
+        # tensor-name list would be silently swallowed.
+        return escape("\n".join(lines))
 
 
 def resolve_shards(directory: Path) -> list[Path]:
@@ -125,7 +112,7 @@ def resolve_shards(directory: Path) -> list[Path]:
     # save_pretrained only deletes files matching (.*?)-\d{5}-of-\d{5}, so a stale
     # index survives an unsharded save and a stale model.safetensors survives a
     # sharded one. Filtering index entries by existence resolves both directions.
-    index_path = directory / SAFE_WEIGHTS_INDEX_NAME
+    index_path = directory / SAFETENSORS_INDEX_FILE
     if index_path.is_file():
         try:
             with index_path.open("r", encoding="utf-8") as file:
@@ -141,460 +128,53 @@ def resolve_shards(directory: Path) -> list[Path]:
         if shards:
             return shards
 
-    single_file = directory / SAFE_WEIGHTS_NAME
+    single_file = directory / SAFETENSORS_SINGLE_FILE
     return [single_file] if single_file.is_file() else []
 
 
-def read_safetensors_header(path: Path) -> dict[str, Any]:
-    with path.open("rb") as file:
-        prefix = file.read(8)
-        if len(prefix) != 8:
-            raise TensorCheckError(f"{path}: truncated length prefix")
-        (length,) = struct.unpack("<Q", prefix)
-        header = file.read(length)
-        if len(header) != length:
-            raise TensorCheckError(f"{path}: truncated header")
-
-    return json.loads(header.decode("utf-8"))
-
-
 def read_checkpoint_index(directory: Path) -> CheckpointIndex:
-    index: CheckpointIndex = {}
-
-    for shard in resolve_shards(directory):
-        for name, entry in read_safetensors_header(shard).items():
-            if name == "__metadata__":
-                continue
-            start, end = entry["data_offsets"]
-            index[name] = (
-                str(entry["dtype"]),
-                tuple(int(dimension) for dimension in entry["shape"]),
-                int(end) - int(start),
-            )
-
-    return index
-
-
-@dataclass
-class Captures:
-    missing_keys: set[str] = field(default_factory=set)
-    unexpected_keys: set[str] = field(default_factory=set)
-    suppression_patterns: list[str] = field(default_factory=list)
-    held_names: set[str] = field(default_factory=set)
-    tied_groups: list[set[str]] = field(default_factory=list)
-    transpose_patterns: list[str] = field(default_factory=list)
-
-
-def capture_state(
-    model: Any,
-    missing_keys: Iterable[str],
-    unexpected_keys: Iterable[str],
-) -> Captures:
-    """Collects everything the whitelist needs from the freshly loaded model.
-
-    Must be called on the bare PreTrainedModel, before PEFT wrapping. A PeftModel
-    prefixes every state_dict name with "base_model.model.", which leaves zero overlap
-    with the checkpoint namespace and makes all three suppression guards vacuous, and
-    its class does not declare _keys_to_ignore_on_load_unexpected at all.
-    """
-    return Captures(
-        missing_keys=set(missing_keys),
-        unexpected_keys=set(unexpected_keys),
-        suppression_patterns=capture_suppression_patterns(model),
-        # Capturing this before any writer runs is what makes the second suppression
-        # guard meaningful. A set derived at a call site would be downstream of the
-        # component under test.
-        held_names=set(model.state_dict().keys()),
-        tied_groups=capture_tied_groups(model),
-        transpose_patterns=capture_transpose_patterns(model),
-    )
-
-
-def capture_suppression_patterns(model: Any) -> list[str]:
-    # list() rather than augmented assignment: += would bind and mutate the
-    # transformers class attribute, which is a live list on several models.
-    patterns = list(
-        getattr(type(model), "_keys_to_ignore_on_load_unexpected", None) or []
-    )
-
-    if any(name.endswith("rotary_emb.inv_freq") for name, _ in model.named_buffers()):
-        patterns.append(r"rotary_emb\.inv_freq")
-
-    return patterns
-
-
-def capture_tied_groups(model: Any) -> list[set[str]]:
-    # Grouped by shared source rather than per pair. Where three or more names tie to
-    # one weight, as in ProphetNetForCausalLM, per-pair grouping is non-transitive and
-    # leaves the two targets in separate groups.
-    mapping = getattr(model, "all_tied_weights_keys", None) or {}
-
-    groups: dict[str, set[str]] = {}
-    for target, source in mapping.items():
-        groups.setdefault(source, {source}).add(target)
-
-    return [group for group in groups.values() if len(group) > 1]
-
-
-def capture_transpose_patterns(model: Any) -> list[str]:
-    """Returns the target patterns of any converter that transposes without renaming.
-
-    A predicate read of the conversion mapping, not a reimplementation of the reverse
-    conversion. Only qwen3_vl_moe and ernie4_5_vl_moe declare a Transpose at all in
-    transformers 5.3.0, and any failure yields an empty list, which forgives nothing.
-    """
-    try:
-        from transformers.conversion_mapping import get_model_conversion_mapping
-        from transformers.core_model_loading import Transpose, WeightConverter
-    except Exception:
-        return []
-
-    patterns: list[str] = []
-
-    try:
-        for converter in get_model_conversion_mapping(model):
-            if not isinstance(converter, WeightConverter):
-                continue
-            operations = getattr(converter, "operations", None) or []
-            if not any(isinstance(operation, Transpose) for operation in operations):
-                continue
-
-            source_patterns = list(getattr(converter, "source_patterns", None) or [])
-            target_patterns = list(getattr(converter, "target_patterns", None) or [])
-            if source_patterns and source_patterns == target_patterns:
-                patterns.extend(str(pattern) for pattern in target_patterns)
-    except Exception:
-        return []
-
-    return patterns
-
-
-def build_expectation(
-    source_names: set[str],
-    written_names: set[str],
-    captures: Captures,
-) -> tuple[set[str], list[Claim]]:
-    claims: list[Claim] = []
-
-    reported_unexpected = source_names & captures.unexpected_keys
-    for name in sorted(reported_unexpected):
-        claims.append(Claim(name, "E1", "reported in unexpected_keys"))
-
-    # Transformers drops keys matching these patterns from the report it returns, so a
-    # formula resting on unexpected_keys alone rejects a correct save of any checkpoint
-    # carrying legacy per-layer rotary_emb.inv_freq keys.
-    #
-    # All three guards are load-bearing and none subsumes the others. Absence from the
-    # artifact alone is self-fulfilling, since the writer is the thing under test and a
-    # defect that drops a matched name creates the condition that forgives it. Not
-    # being held by the model is fixed before the writer runs, but goes vacuous
-    # wherever the model holds the tensor under another name. The module path prefix
-    # covers that: fusion preserves the path, so a fused parameter's module is a prefix
-    # of every name fusing into it, while a ghost layer is not a module the model has.
-    # Both cases are live on Glm4MoeForCausalLM, which declares an ignore pattern for
-    # layer 46 that is an ordinary layer on the 92-layer GLM-4.5 and GLM-4.6.
-    #
-    # inv_freq is exempted from the third guard because GptOssAttention registers sinks
-    # directly on self_attn, making it a held module path. Those keys are transformers'
-    # own unconditional pattern and name non-persistent buffers, so they cannot be a
-    # corruption signal in the first place.
-    held_modules = {name.rsplit(".", 1)[0] for name in captures.held_names}
-    suppressed = {
-        name
-        for name in source_names
-        if name not in written_names
-        and name not in captures.held_names
-        and (
-            name.endswith("rotary_emb.inv_freq")
-            or not any(name.startswith(module + ".") for module in held_modules)
-        )
-        and any(re.search(pattern, name) for pattern in captures.suppression_patterns)
+    return {
+        name: (tuple(info.shape), info.data_offsets[1] - info.data_offsets[0])
+        for shard in resolve_shards(directory)
+        for name, info in parse_local_safetensors_file_metadata(shard).tensors.items()
     }
-    for name in sorted(suppressed):
-        claims.append(Claim(name, "E2", "matches a suppressed-unexpected pattern"))
-
-    # A missing_keys name absent from both headers is a model-namespace name with no
-    # checkpoint-namespace counterpart, so it cannot be an expectation about what the
-    # writer emits. Injecting it anyway is what made byte-correct saves of fused MoE
-    # checkpoints report absences.
-    locatable = captures.missing_keys & (source_names | written_names)
-    for name in sorted(locatable):
-        claims.append(Claim(name, "E3", "reported in missing_keys, newly initialized"))
-    for name in sorted(captures.missing_keys - locatable):
-        claims.append(Claim(name, "E6", "in missing_keys but in neither header"))
-
-    expectation = (source_names - reported_unexpected - suppressed) | locatable
-    return expectation, claims
 
 
-def canonicalise(names: set[str], tied_groups: Sequence[set[str]]) -> set[str]:
-    result = set(names)
-
-    for group in tied_groups:
-        if result & group:
-            result -= group
-            result.add(min(group))
-
-    return result
-
-
-def claim_absences(
-    absent: set[str],
-    source_names: set[str],
-    written_names: set[str],
-    captures: Captures,
-) -> tuple[set[str], list[Claim]]:
-    # The basis is restricted to unexpected_keys because the two halves of the load
-    # report are not symmetric. An unexpected_keys name describes something the
-    # checkpoint has and the model does not, so it is absent from the artifact by
-    # construction and no writer can move it in or out of the un-locatable set. A
-    # missing_keys name is written on a correct save, so a defect that drops it would
-    # otherwise promote its own module path into the basis and excuse every absent
-    # sibling under it.
-    unlocatable = (captures.missing_keys | captures.unexpected_keys) - (
-        source_names | written_names
-    )
-    basis = unlocatable & captures.unexpected_keys
-    modules = {name.rsplit(".", 1)[0] for name in basis}
-
-    claims: list[Claim] = []
-    unclaimed: set[str] = set()
-
-    for name in sorted(absent):
-        # The prefix relation enforces its own precondition. Fusion preserves the
-        # module path only where the converter does not also rename, so on a renaming
-        # converter such as the Mixtral family's nothing matches, nothing is claimed,
-        # and the name is reported.
-        module = next(
-            (module for module in modules if name.startswith(module + ".")), None
-        )
-        if module is None:
-            unclaimed.add(name)
-        else:
-            claims.append(Claim(name, "E5", f"fuses into un-locatable {module}"))
-
-    return unclaimed, claims
-
-
-def claim_shape(
-    name: str,
-    source_shape: tuple[int, ...],
-    written_shape: tuple[int, ...],
-    captures: Captures,
-) -> Claim | None:
-    # Scoped per name rather than per model, so a model declaring such a converter
-    # still has every other tensor's permutation treated as a defect. gpt-oss declares
-    # none, which matters because its expert scales are (32, 2880, 90) and
-    # (32, 5760, 90): unequal in the transposed dimensions, so a permutation there is
-    # visible in the header and is rejected.
-    if sorted(source_shape) != sorted(written_shape):
-        return None
-
-    for pattern in captures.transpose_patterns:
-        try:
-            matched = re.search(pattern, name) is not None
-        except re.error:
-            matched = pattern in name
-
-        if matched:
-            return Claim(
-                name,
-                "E7",
-                f"permutation {source_shape} -> {written_shape} on a declared "
-                f"transpose converter",
-            )
-
-    return None
-
-
-def compose_failure_message(
-    result: CheckResult, context: str, written_directory: Path
-) -> str:
-    lines = [
-        "Tensor name verification failed: the saved model does not carry the names "
-        "and shapes of the source checkpoint.",
-        "Heretic rewrites values and never renames, so a correct save writes exactly "
-        "the source's names with the source's shapes.",
-        f"  source names: {result.source_count}, written names: {result.written_count}",
-    ]
-
-    if result.unclaimed_shape:
-        lines.append(f"  unexplained shape differences: {len(result.unclaimed_shape)}")
-        for name, source_shape, written_shape in sorted(result.unclaimed_shape)[:5]:
-            lines.append(f"    {name}: {source_shape} -> {written_shape}")
-
-    if result.unclaimed_absent:
-        lines.append(f"  expected but not written: {len(result.unclaimed_absent)}")
-        for name in sorted(result.unclaimed_absent)[:5]:
-            lines.append(f"    {name}")
-
-    # What was written in their place is the half that identifies the defect: the
-    # reported one is recognizable on sight, by names ending in _blocks_blocks.
-    if result.unclaimed_extra:
-        lines.append(f"  written but not expected: {len(result.unclaimed_extra)}")
-        for name in sorted(result.unclaimed_extra)[:5]:
-            lines.append(f"    {name}")
-
-    # Derived from the ledger rather than enumerated. Hand-written lists of the benign
-    # causes of a rejection went stale every time the whitelist changed, either naming
-    # a cause that had been closed or omitting one that had been opened.
-    fired = result.claims_by_entry()
-    if fired:
-        lines.append("  whitelist entries that did apply:")
-        for entry_id in sorted(fired):
-            lines.append(
-                f"    {entry_id} {WHITELIST[entry_id].title}: {fired[entry_id]} name(s)"
-            )
-    else:
-        lines.append("  no whitelist entry applied.")
-
-    lines.append(
-        "  This is usually a serialization bug in transformers rather than anything "
-        "abliteration did. Known defects of this shape affect MXFP4 checkpoints on "
-        "5.4.0 through 5.5.1 and from 5.5.2 onward, and vision-language checkpoints "
-        "on 5.4.0 through 5.5.4."
-    )
-
-    if context == "preflight":
-        lines.append(
-            "  This was a trial save made before any optimization, so no work has "
-            "been lost. Pass --no-preflight-save-check to skip the trial; the "
-            "post-save and upload checks are not affected by that flag."
-        )
-        lines.append(f"  The trial save has been kept at {written_directory}.")
-    elif context == "upload":
-        lines.append(f"  Nothing was uploaded. The model is at {written_directory}.")
-    else:
-        lines.append(
-            f"  The model at {written_directory} was already written when this was "
-            "detected, and has been left alone. Saving is destructive in place, so if "
-            "that folder held an earlier model, it is gone."
-        )
-
-    return escape("\n".join(lines))
-
-
-def compose_warning_message(result: CheckResult) -> str:
-    lines = [
-        f"Tensor name check: the saved model carries {len(result.unclaimed_extra)} "
-        "name(s) that the source checkpoint does not.",
-        "Every expected name is present at the expected shape, so this is not "
-        "corruption; the extra tensors are reported as unexpected on load and ignored.",
-        f"  source names: {result.source_count}, written names: {result.written_count}",
-    ]
-
-    for name in sorted(result.unclaimed_extra)[:5]:
-        lines.append(f"    {name}")
-    if len(result.unclaimed_extra) > 5:
-        lines.append(f"    ... and {len(result.unclaimed_extra) - 5} more")
-
-    return escape("\n".join(lines))
-
-
-def check_checkpoint(
+def compare_checkpoint(
     written_directory: Path,
-    source_index: Mapping[str, tuple[str, tuple[int, ...], int]],
-    captures: Captures,
-    context: str,
+    source_index: Mapping[str, tuple[tuple[int, ...], int]],
 ) -> CheckResult:
-    result = CheckResult(verdict="pass")
-
     if not source_index:
-        result.verdict = "unavailable"
-        result.reason = (
-            "the source checkpoint has no safetensors shards to compare against"
+        return CheckResult(
+            verdict=Verdict.UNAVAILABLE,
+            reason="no source checkpoint index to compare against",
         )
-        return result
 
     written_index = read_checkpoint_index(written_directory)
-    result.source_count = len(source_index)
-    result.written_count = len(written_index)
+    result = CheckResult(
+        verdict=Verdict.CLEAN,
+        source_count=len(source_index),
+        written_count=len(written_index),
+    )
 
     if not written_index:
-        result.verdict = "fail"
+        result.verdict = Verdict.NO_WEIGHTS
         result.reason = "no safetensors shards were written"
-        result.message = result.reason
         return result
 
     source_names = set(source_index)
     written_names = set(written_index)
 
-    expectation, claims = build_expectation(source_names, written_names, captures)
-    result.claims.extend(claims)
+    result.absent = sorted(source_names - written_names)
+    result.extra = sorted(written_names - source_names)
 
-    expected_canonical = canonicalise(expectation, captures.tied_groups)
-    written_canonical = canonicalise(written_names, captures.tied_groups)
-    for group in captures.tied_groups:
-        expected_members = expectation & group
-        written_members = written_names & group
-        if expected_members and written_members and expected_members != written_members:
-            result.claims.append(
-                Claim(min(group), "E4", f"tie group {sorted(group)} canonicalised")
-            )
+    result.shape_mismatches = [
+        (name, source_index[name][0], written_index[name][0])
+        for name in sorted(source_names & written_names)
+        if source_index[name][0] != written_index[name][0]
+    ]
 
-    unclaimed_absent, absence_claims = claim_absences(
-        expected_canonical - written_canonical, source_names, written_names, captures
-    )
-    result.claims.extend(absence_claims)
-    result.unclaimed_absent = sorted(unclaimed_absent)
-    result.unclaimed_extra = sorted(written_canonical - expected_canonical)
-
-    for name in sorted(source_names & written_names):
-        _, source_shape, _ = source_index[name]
-        _, written_shape, _ = written_index[name]
-        if source_shape == written_shape:
-            continue
-
-        claim = claim_shape(name, source_shape, written_shape, captures)
-        if claim is None:
-            result.unclaimed_shape.append((name, source_shape, written_shape))
-        else:
-            result.claims.append(claim)
-
-    # A tensor written under the right name with the wrong geometry is corruption even
-    # though nothing is missing, so shapes are decided first. Extras on their own are
-    # not: every expected tensor is present at the expected shape, so the model loads
-    # and computes correctly and the extra names are ignored on load.
-    if result.unclaimed_shape:
-        result.verdict = "fail"
-        result.reason = f"{len(result.unclaimed_shape)} unexplained shape difference(s)"
-        result.message = compose_failure_message(result, context, written_directory)
-    elif result.unclaimed_absent:
-        result.verdict = "fail"
-        result.reason = (
-            f"{len(result.unclaimed_absent)} expected tensor name(s) were not written"
-        )
-        result.message = compose_failure_message(result, context, written_directory)
-    elif result.unclaimed_extra:
-        result.verdict = "warn"
-        result.reason = f"{len(result.unclaimed_extra)} unexpected extra name(s)"
-        result.message = compose_warning_message(result)
-    else:
-        result.reason = "written names and shapes match the source checkpoint"
+    if result.absent or result.extra or result.shape_mismatches:
+        result.verdict = Verdict.DIFFERS
 
     return result
-
-
-def verify_checkpoint(
-    written_directory: Path,
-    source_index: Mapping[str, tuple[str, tuple[int, ...], int]],
-    captures: Captures,
-    context: str = "postsave",
-    confirm: Callable[[CheckResult], bool] | None = None,
-) -> None:
-    result = check_checkpoint(written_directory, source_index, captures, context)
-
-    if result.verdict == "unavailable":
-        print(f"* Tensor name check skipped: {result.reason}")
-        return
-
-    if result.verdict == "warn":
-        print(f"[yellow]{result.message}[/]")
-        if confirm is not None and not confirm(result):
-            raise TensorCheckError(
-                f"Upload cancelled. The model is still at {written_directory}."
-            )
-        return
-
-    if result.verdict == "fail":
-        raise TensorCheckError(result.message)

--- a/src/heretic/tensor_check.py
+++ b/src/heretic/tensor_check.py
@@ -1,0 +1,600 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2025-2026  Philipp Emanuel Weidmann <pew@worldwidemann.com> + contributors
+
+import json
+import re
+import struct
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Iterable, Mapping, Sequence
+
+from rich.markup import escape
+from transformers.utils import SAFE_WEIGHTS_INDEX_NAME, SAFE_WEIGHTS_NAME
+
+from .utils import print
+
+
+class TensorCheckError(Exception):
+    pass
+
+
+@dataclass(frozen=True)
+class Entry:
+    id: str
+    title: str
+    mechanism: str
+
+
+# Every reason a written name may legitimately differ from the source checkpoint is
+# one of these, and each claims a specific name by naming the mechanism that entails
+# it. A name that no entry claims is unexplained, and unexplained means rejection.
+# Widening a comparison to accommodate a new case is never correct here; adding an
+# entry that states its mechanism is.
+WHITELIST = {
+    entry.id: entry
+    for entry in [
+        Entry(
+            "E1",
+            "reported unexpected",
+            "the loader reported this exact key in unexpected_keys, so the model never "
+            "registered it and the writer will not emit it",
+        ),
+        Entry(
+            "E2",
+            "suppressed unexpected",
+            "this name matches a pattern transformers applies to unexpected keys but "
+            "filters out of its own report, and it is not a live tensor",
+        ),
+        Entry(
+            "E3",
+            "newly initialized",
+            "the loader reported this exact key in missing_keys, so transformers "
+            "initialized it and the writer emits it although the source lacked it",
+        ),
+        Entry(
+            "E4",
+            "tie group",
+            "this name and that one tie to a single weight; safetensors forbids "
+            "aliasing, so which of them is written is transformers' choice",
+        ),
+        Entry(
+            "E5",
+            "converter fan-in",
+            "this absent source name lies under the module path of an un-locatable "
+            "unexpected_keys name, so it fuses into that parameter",
+        ),
+        Entry(
+            "E6",
+            "namespace un-locatable",
+            "this missing_keys name is in neither header, so it is a model-namespace "
+            "name that cannot be an expectation about checkpoint-namespace output",
+        ),
+        Entry(
+            "E7",
+            "declined reverse transpose",
+            "the model declares a converter whose source and target patterns are "
+            "identical and which transposes, and on save the reverse operation finds "
+            "the tensor already matching and declines to transpose back",
+        ),
+    ]
+}
+
+
+@dataclass
+class Claim:
+    name: str
+    entry: str
+    detail: str = ""
+
+
+# Name -> (dtype, shape, nbytes). The dtype is carried for the memory estimate in
+# model.py and is never compared: a correct transformers 5.3.0 save of gpt-oss widens
+# 48 expert bias tensors from BF16 to F32, so comparing dtype would reject the very
+# model this check exists to protect.
+CheckpointIndex = dict[str, tuple[str, tuple[int, ...], int]]
+
+
+@dataclass
+class CheckResult:
+    verdict: str
+    reason: str = ""
+    message: str = ""
+
+    source_count: int = 0
+    written_count: int = 0
+
+    unclaimed_absent: list[str] = field(default_factory=list)
+    unclaimed_extra: list[str] = field(default_factory=list)
+    unclaimed_shape: list[tuple[str, tuple[int, ...], tuple[int, ...]]] = field(
+        default_factory=list
+    )
+    claims: list[Claim] = field(default_factory=list)
+
+    def claims_by_entry(self) -> dict[str, int]:
+        counts: dict[str, int] = {}
+        for claim in self.claims:
+            counts[claim.entry] = counts.get(claim.entry, 0) + 1
+        return counts
+
+
+def resolve_shards(directory: Path) -> list[Path]:
+    # Globbing over-collects: Mistral-7B-Instruct-v0.3 ships a top-level
+    # consolidated.safetensors holding 291 tensors in a naming transformers never
+    # reads, and a reused output directory can hold a previous run's adapter or shards.
+    #
+    # save_pretrained only deletes files matching (.*?)-\d{5}-of-\d{5}, so a stale
+    # index survives an unsharded save and a stale model.safetensors survives a
+    # sharded one. Filtering index entries by existence resolves both directions.
+    index_path = directory / SAFE_WEIGHTS_INDEX_NAME
+    if index_path.is_file():
+        try:
+            with index_path.open("r", encoding="utf-8") as file:
+                weight_map = json.load(file)["weight_map"]
+            names = {str(shard) for shard in weight_map.values()}
+        except Exception:
+            names = set()
+
+        shards = sorted(
+            {directory / name for name in names if (directory / name).is_file()},
+            key=lambda path: path.name,
+        )
+        if shards:
+            return shards
+
+    single_file = directory / SAFE_WEIGHTS_NAME
+    return [single_file] if single_file.is_file() else []
+
+
+def read_safetensors_header(path: Path) -> dict[str, Any]:
+    with path.open("rb") as file:
+        prefix = file.read(8)
+        if len(prefix) != 8:
+            raise TensorCheckError(f"{path}: truncated length prefix")
+        (length,) = struct.unpack("<Q", prefix)
+        header = file.read(length)
+        if len(header) != length:
+            raise TensorCheckError(f"{path}: truncated header")
+
+    return json.loads(header.decode("utf-8"))
+
+
+def read_checkpoint_index(directory: Path) -> CheckpointIndex:
+    index: CheckpointIndex = {}
+
+    for shard in resolve_shards(directory):
+        for name, entry in read_safetensors_header(shard).items():
+            if name == "__metadata__":
+                continue
+            start, end = entry["data_offsets"]
+            index[name] = (
+                str(entry["dtype"]),
+                tuple(int(dimension) for dimension in entry["shape"]),
+                int(end) - int(start),
+            )
+
+    return index
+
+
+@dataclass
+class Captures:
+    missing_keys: set[str] = field(default_factory=set)
+    unexpected_keys: set[str] = field(default_factory=set)
+    suppression_patterns: list[str] = field(default_factory=list)
+    held_names: set[str] = field(default_factory=set)
+    tied_groups: list[set[str]] = field(default_factory=list)
+    transpose_patterns: list[str] = field(default_factory=list)
+
+
+def capture_state(
+    model: Any,
+    missing_keys: Iterable[str],
+    unexpected_keys: Iterable[str],
+) -> Captures:
+    """Collects everything the whitelist needs from the freshly loaded model.
+
+    Must be called on the bare PreTrainedModel, before PEFT wrapping. A PeftModel
+    prefixes every state_dict name with "base_model.model.", which leaves zero overlap
+    with the checkpoint namespace and makes all three suppression guards vacuous, and
+    its class does not declare _keys_to_ignore_on_load_unexpected at all.
+    """
+    return Captures(
+        missing_keys=set(missing_keys),
+        unexpected_keys=set(unexpected_keys),
+        suppression_patterns=capture_suppression_patterns(model),
+        # Capturing this before any writer runs is what makes the second suppression
+        # guard meaningful. A set derived at a call site would be downstream of the
+        # component under test.
+        held_names=set(model.state_dict().keys()),
+        tied_groups=capture_tied_groups(model),
+        transpose_patterns=capture_transpose_patterns(model),
+    )
+
+
+def capture_suppression_patterns(model: Any) -> list[str]:
+    # list() rather than augmented assignment: += would bind and mutate the
+    # transformers class attribute, which is a live list on several models.
+    patterns = list(
+        getattr(type(model), "_keys_to_ignore_on_load_unexpected", None) or []
+    )
+
+    if any(name.endswith("rotary_emb.inv_freq") for name, _ in model.named_buffers()):
+        patterns.append(r"rotary_emb\.inv_freq")
+
+    return patterns
+
+
+def capture_tied_groups(model: Any) -> list[set[str]]:
+    # Grouped by shared source rather than per pair. Where three or more names tie to
+    # one weight, as in ProphetNetForCausalLM, per-pair grouping is non-transitive and
+    # leaves the two targets in separate groups.
+    mapping = getattr(model, "all_tied_weights_keys", None) or {}
+
+    groups: dict[str, set[str]] = {}
+    for target, source in mapping.items():
+        groups.setdefault(source, {source}).add(target)
+
+    return [group for group in groups.values() if len(group) > 1]
+
+
+def capture_transpose_patterns(model: Any) -> list[str]:
+    """Returns the target patterns of any converter that transposes without renaming.
+
+    A predicate read of the conversion mapping, not a reimplementation of the reverse
+    conversion. Only qwen3_vl_moe and ernie4_5_vl_moe declare a Transpose at all in
+    transformers 5.3.0, and any failure yields an empty list, which forgives nothing.
+    """
+    try:
+        from transformers.conversion_mapping import get_model_conversion_mapping
+        from transformers.core_model_loading import Transpose, WeightConverter
+    except Exception:
+        return []
+
+    patterns: list[str] = []
+
+    try:
+        for converter in get_model_conversion_mapping(model):
+            if not isinstance(converter, WeightConverter):
+                continue
+            operations = getattr(converter, "operations", None) or []
+            if not any(isinstance(operation, Transpose) for operation in operations):
+                continue
+
+            source_patterns = list(getattr(converter, "source_patterns", None) or [])
+            target_patterns = list(getattr(converter, "target_patterns", None) or [])
+            if source_patterns and source_patterns == target_patterns:
+                patterns.extend(str(pattern) for pattern in target_patterns)
+    except Exception:
+        return []
+
+    return patterns
+
+
+def build_expectation(
+    source_names: set[str],
+    written_names: set[str],
+    captures: Captures,
+) -> tuple[set[str], list[Claim]]:
+    claims: list[Claim] = []
+
+    reported_unexpected = source_names & captures.unexpected_keys
+    for name in sorted(reported_unexpected):
+        claims.append(Claim(name, "E1", "reported in unexpected_keys"))
+
+    # Transformers drops keys matching these patterns from the report it returns, so a
+    # formula resting on unexpected_keys alone rejects a correct save of any checkpoint
+    # carrying legacy per-layer rotary_emb.inv_freq keys.
+    #
+    # All three guards are load-bearing and none subsumes the others. Absence from the
+    # artifact alone is self-fulfilling, since the writer is the thing under test and a
+    # defect that drops a matched name creates the condition that forgives it. Not
+    # being held by the model is fixed before the writer runs, but goes vacuous
+    # wherever the model holds the tensor under another name. The module path prefix
+    # covers that: fusion preserves the path, so a fused parameter's module is a prefix
+    # of every name fusing into it, while a ghost layer is not a module the model has.
+    # Both cases are live on Glm4MoeForCausalLM, which declares an ignore pattern for
+    # layer 46 that is an ordinary layer on the 92-layer GLM-4.5 and GLM-4.6.
+    #
+    # inv_freq is exempted from the third guard because GptOssAttention registers sinks
+    # directly on self_attn, making it a held module path. Those keys are transformers'
+    # own unconditional pattern and name non-persistent buffers, so they cannot be a
+    # corruption signal in the first place.
+    held_modules = {name.rsplit(".", 1)[0] for name in captures.held_names}
+    suppressed = {
+        name
+        for name in source_names
+        if name not in written_names
+        and name not in captures.held_names
+        and (
+            name.endswith("rotary_emb.inv_freq")
+            or not any(name.startswith(module + ".") for module in held_modules)
+        )
+        and any(re.search(pattern, name) for pattern in captures.suppression_patterns)
+    }
+    for name in sorted(suppressed):
+        claims.append(Claim(name, "E2", "matches a suppressed-unexpected pattern"))
+
+    # A missing_keys name absent from both headers is a model-namespace name with no
+    # checkpoint-namespace counterpart, so it cannot be an expectation about what the
+    # writer emits. Injecting it anyway is what made byte-correct saves of fused MoE
+    # checkpoints report absences.
+    locatable = captures.missing_keys & (source_names | written_names)
+    for name in sorted(locatable):
+        claims.append(Claim(name, "E3", "reported in missing_keys, newly initialized"))
+    for name in sorted(captures.missing_keys - locatable):
+        claims.append(Claim(name, "E6", "in missing_keys but in neither header"))
+
+    expectation = (source_names - reported_unexpected - suppressed) | locatable
+    return expectation, claims
+
+
+def canonicalise(names: set[str], tied_groups: Sequence[set[str]]) -> set[str]:
+    result = set(names)
+
+    for group in tied_groups:
+        if result & group:
+            result -= group
+            result.add(min(group))
+
+    return result
+
+
+def claim_absences(
+    absent: set[str],
+    source_names: set[str],
+    written_names: set[str],
+    captures: Captures,
+) -> tuple[set[str], list[Claim]]:
+    # The basis is restricted to unexpected_keys because the two halves of the load
+    # report are not symmetric. An unexpected_keys name describes something the
+    # checkpoint has and the model does not, so it is absent from the artifact by
+    # construction and no writer can move it in or out of the un-locatable set. A
+    # missing_keys name is written on a correct save, so a defect that drops it would
+    # otherwise promote its own module path into the basis and excuse every absent
+    # sibling under it.
+    unlocatable = (captures.missing_keys | captures.unexpected_keys) - (
+        source_names | written_names
+    )
+    basis = unlocatable & captures.unexpected_keys
+    modules = {name.rsplit(".", 1)[0] for name in basis}
+
+    claims: list[Claim] = []
+    unclaimed: set[str] = set()
+
+    for name in sorted(absent):
+        # The prefix relation enforces its own precondition. Fusion preserves the
+        # module path only where the converter does not also rename, so on a renaming
+        # converter such as the Mixtral family's nothing matches, nothing is claimed,
+        # and the name is reported.
+        module = next(
+            (module for module in modules if name.startswith(module + ".")), None
+        )
+        if module is None:
+            unclaimed.add(name)
+        else:
+            claims.append(Claim(name, "E5", f"fuses into un-locatable {module}"))
+
+    return unclaimed, claims
+
+
+def claim_shape(
+    name: str,
+    source_shape: tuple[int, ...],
+    written_shape: tuple[int, ...],
+    captures: Captures,
+) -> Claim | None:
+    # Scoped per name rather than per model, so a model declaring such a converter
+    # still has every other tensor's permutation treated as a defect. gpt-oss declares
+    # none, which matters because its expert scales are (32, 2880, 90) and
+    # (32, 5760, 90): unequal in the transposed dimensions, so a permutation there is
+    # visible in the header and is rejected.
+    if sorted(source_shape) != sorted(written_shape):
+        return None
+
+    for pattern in captures.transpose_patterns:
+        try:
+            matched = re.search(pattern, name) is not None
+        except re.error:
+            matched = pattern in name
+
+        if matched:
+            return Claim(
+                name,
+                "E7",
+                f"permutation {source_shape} -> {written_shape} on a declared "
+                f"transpose converter",
+            )
+
+    return None
+
+
+def compose_failure_message(
+    result: CheckResult, context: str, written_directory: Path
+) -> str:
+    lines = [
+        "Tensor name verification failed: the saved model does not carry the names "
+        "and shapes of the source checkpoint.",
+        "Heretic rewrites values and never renames, so a correct save writes exactly "
+        "the source's names with the source's shapes.",
+        f"  source names: {result.source_count}, written names: {result.written_count}",
+    ]
+
+    if result.unclaimed_shape:
+        lines.append(f"  unexplained shape differences: {len(result.unclaimed_shape)}")
+        for name, source_shape, written_shape in sorted(result.unclaimed_shape)[:5]:
+            lines.append(f"    {name}: {source_shape} -> {written_shape}")
+
+    if result.unclaimed_absent:
+        lines.append(f"  expected but not written: {len(result.unclaimed_absent)}")
+        for name in sorted(result.unclaimed_absent)[:5]:
+            lines.append(f"    {name}")
+
+    # What was written in their place is the half that identifies the defect: the
+    # reported one is recognizable on sight, by names ending in _blocks_blocks.
+    if result.unclaimed_extra:
+        lines.append(f"  written but not expected: {len(result.unclaimed_extra)}")
+        for name in sorted(result.unclaimed_extra)[:5]:
+            lines.append(f"    {name}")
+
+    # Derived from the ledger rather than enumerated. Hand-written lists of the benign
+    # causes of a rejection went stale every time the whitelist changed, either naming
+    # a cause that had been closed or omitting one that had been opened.
+    fired = result.claims_by_entry()
+    if fired:
+        lines.append("  whitelist entries that did apply:")
+        for entry_id in sorted(fired):
+            lines.append(
+                f"    {entry_id} {WHITELIST[entry_id].title}: {fired[entry_id]} name(s)"
+            )
+    else:
+        lines.append("  no whitelist entry applied.")
+
+    lines.append(
+        "  This is usually a serialization bug in transformers rather than anything "
+        "abliteration did. Known defects of this shape affect MXFP4 checkpoints on "
+        "5.4.0 through 5.5.1 and from 5.5.2 onward, and vision-language checkpoints "
+        "on 5.4.0 through 5.5.4."
+    )
+
+    if context == "preflight":
+        lines.append(
+            "  This was a trial save made before any optimization, so no work has "
+            "been lost. Pass --no-preflight-save-check to skip the trial; the "
+            "post-save and upload checks are not affected by that flag."
+        )
+        lines.append(f"  The trial save has been kept at {written_directory}.")
+    elif context == "upload":
+        lines.append(f"  Nothing was uploaded. The model is at {written_directory}.")
+    else:
+        lines.append(
+            f"  The model at {written_directory} was already written when this was "
+            "detected, and has been left alone. Saving is destructive in place, so if "
+            "that folder held an earlier model, it is gone."
+        )
+
+    return escape("\n".join(lines))
+
+
+def compose_warning_message(result: CheckResult) -> str:
+    lines = [
+        f"Tensor name check: the saved model carries {len(result.unclaimed_extra)} "
+        "name(s) that the source checkpoint does not.",
+        "Every expected name is present at the expected shape, so this is not "
+        "corruption; the extra tensors are reported as unexpected on load and ignored.",
+        f"  source names: {result.source_count}, written names: {result.written_count}",
+    ]
+
+    for name in sorted(result.unclaimed_extra)[:5]:
+        lines.append(f"    {name}")
+    if len(result.unclaimed_extra) > 5:
+        lines.append(f"    ... and {len(result.unclaimed_extra) - 5} more")
+
+    return escape("\n".join(lines))
+
+
+def check_checkpoint(
+    written_directory: Path,
+    source_index: Mapping[str, tuple[str, tuple[int, ...], int]],
+    captures: Captures,
+    context: str,
+) -> CheckResult:
+    result = CheckResult(verdict="pass")
+
+    if not source_index:
+        result.verdict = "unavailable"
+        result.reason = (
+            "the source checkpoint has no safetensors shards to compare against"
+        )
+        return result
+
+    written_index = read_checkpoint_index(written_directory)
+    result.source_count = len(source_index)
+    result.written_count = len(written_index)
+
+    if not written_index:
+        result.verdict = "fail"
+        result.reason = "no safetensors shards were written"
+        result.message = result.reason
+        return result
+
+    source_names = set(source_index)
+    written_names = set(written_index)
+
+    expectation, claims = build_expectation(source_names, written_names, captures)
+    result.claims.extend(claims)
+
+    expected_canonical = canonicalise(expectation, captures.tied_groups)
+    written_canonical = canonicalise(written_names, captures.tied_groups)
+    for group in captures.tied_groups:
+        expected_members = expectation & group
+        written_members = written_names & group
+        if expected_members and written_members and expected_members != written_members:
+            result.claims.append(
+                Claim(min(group), "E4", f"tie group {sorted(group)} canonicalised")
+            )
+
+    unclaimed_absent, absence_claims = claim_absences(
+        expected_canonical - written_canonical, source_names, written_names, captures
+    )
+    result.claims.extend(absence_claims)
+    result.unclaimed_absent = sorted(unclaimed_absent)
+    result.unclaimed_extra = sorted(written_canonical - expected_canonical)
+
+    for name in sorted(source_names & written_names):
+        _, source_shape, _ = source_index[name]
+        _, written_shape, _ = written_index[name]
+        if source_shape == written_shape:
+            continue
+
+        claim = claim_shape(name, source_shape, written_shape, captures)
+        if claim is None:
+            result.unclaimed_shape.append((name, source_shape, written_shape))
+        else:
+            result.claims.append(claim)
+
+    # A tensor written under the right name with the wrong geometry is corruption even
+    # though nothing is missing, so shapes are decided first. Extras on their own are
+    # not: every expected tensor is present at the expected shape, so the model loads
+    # and computes correctly and the extra names are ignored on load.
+    if result.unclaimed_shape:
+        result.verdict = "fail"
+        result.reason = f"{len(result.unclaimed_shape)} unexplained shape difference(s)"
+        result.message = compose_failure_message(result, context, written_directory)
+    elif result.unclaimed_absent:
+        result.verdict = "fail"
+        result.reason = (
+            f"{len(result.unclaimed_absent)} expected tensor name(s) were not written"
+        )
+        result.message = compose_failure_message(result, context, written_directory)
+    elif result.unclaimed_extra:
+        result.verdict = "warn"
+        result.reason = f"{len(result.unclaimed_extra)} unexpected extra name(s)"
+        result.message = compose_warning_message(result)
+    else:
+        result.reason = "written names and shapes match the source checkpoint"
+
+    return result
+
+
+def verify_checkpoint(
+    written_directory: Path,
+    source_index: Mapping[str, tuple[str, tuple[int, ...], int]],
+    captures: Captures,
+    context: str = "postsave",
+    confirm: Callable[[CheckResult], bool] | None = None,
+) -> None:
+    result = check_checkpoint(written_directory, source_index, captures, context)
+
+    if result.verdict == "unavailable":
+        print(f"* Tensor name check skipped: {result.reason}")
+        return
+
+    if result.verdict == "warn":
+        print(f"[yellow]{result.message}[/]")
+        if confirm is not None and not confirm(result):
+            raise TensorCheckError(
+                f"Upload cancelled. The model is still at {written_directory}."
+            )
+        return
+
+    if result.verdict == "fail":
+        raise TensorCheckError(result.message)


### PR DESCRIPTION
Note: turns out it was not as straightforward as I thought it would be.

The PR made in response to https://github.com/p-e-w/heretic/pull/211#issuecomment-5101436563. It is probably overengineered but my aims here were:
1. To make sure that what works already mostly keeps working.
2. To make sure that things that break, break loudly, and with exceptions only when the reason for what appears to be a breakage is well-understood and is explicitly considered benign.

This is obviously just the initial version of the feature/fix, and I am willing to explain any unclear parts of the design and to correct any parts which have problems.

What the check does is compare the tensor names and shapes the save actually wrote against the ones in the source checkpoint, reading safetensors headers only, so it costs no measurable time and never loads the artifact back. The invariant it rests on is that Heretic rewrites values and never renames anything. Where a correct save legitimately does differ from its source, the difference is not forgiven by loosening the comparison but by an explicit entry that names the mechanism responsible and claims the specific tensor names that mechanism accounts for, so a name is either explained by exactly one entry or it is unexplained, and unexplained means the save is rejected.

It runs at three points: once before optimization begins, as a trial save on the freshly loaded model so that an environment which cannot serialize the model is caught before hours are spent rather than after, after a local save, and before an upload, on a staged copy, so that a rejected model cannot be published by choosing the upload action after the save action has already reported the problem. Only the first is skippable, with `--no-preflight-save-check`, since the other two are the ones that actually protect anything.

I have tested my design with the following models and got the following results.

Columns are transformers versions. Ten releases were measured, 5.3.0, 5.4.0, 5.5.0, 5.5.1, 5.5.2, 5.5.3, 5.5.4, 5.6.0, 5.8.0 and 5.14.1, and every model behaved identically within the bands shown, so the table is banded rather than repeating ten identical columns. Pass means every tensor in the source checkpoint was written under the same name at the same shape. Fail means at least one name or shape could not be accounted for, and the run stops. Warn means everything expected was written correctly and the artifact additionally carries names the source did not, which (in my testing) loads and computes correctly, so the run continues. The counts are of unexplained differences only, after every applicable exception has been applied, so a non-zero count is one that nothing could account for.

| Model | Tensors in source | 5.3.0 | 5.4.0 - 5.5.4 | 5.6.0 - 5.14.1 |
|---|---|---|---|---|
| `Qwen/Qwen2.5-0.5B-Instruct` | 290 | pass | pass | pass |
| `tiny-random/gpt-oss` | 36 | pass | pass | pass |
| `tiny-random/qwen3-moe` | 46 | pass | pass | pass |
| `tiny-random/glm-4-moe` | 148 | pass | pass | pass |
| `tiny-random/glm-4-moe-lite` | 433 | pass | pass | pass |
| `tiny-random/deepseek-v3.1` | 241 | pass | pass | pass |
| `hf-internal-testing/tiny-random-Qwen3VLMoeForConditionalGeneration` | 376 | pass | pass | pass |
| `tiny-random/gemma-3` | 67 | pass | **fail: 67 absent, 67 extra** | pass |
| `hf-internal-testing/tiny-random-Qwen2VLForConditionalGeneration` | 58 | pass | **fail: 31 absent, 31 extra** | pass |
| `OpenGVLab/InternVL3-1B-hf` | 733 | pass | **fail: 732 absent, 732 extra** | pass |
| `hf-internal-testing/tiny-random-MixtralForCausalLM` | 21 | **fail: 6 absent, 26 extra** | **fail: 6 absent, 26 extra** | pass |
| `PrimeIntellect/GLM-0.5B` | 429 | warn: 0 absent, 552 extra | warn: 0 absent, 552 extra | pass |

Two of those rows need a word before they are read as the check misbehaving, and the Mixtral one especially, since it is the only row that fails on the version `uv.lock` currently pins. `hf-internal-testing/tiny-random-MixtralForCausalLM` is a test fixture stored in the post-conversion naming rather than the on-disk naming everything else uses, so a correct save legitimately un-fuses its 21 tensors into 41, which is where the 6 absent and 26 extra come from. That rejection is, as far as I can tell, a false positive, and covering this class of mismatch under the whitelist is something I plan to do later down the line.

And gpt-oss specifically, checked against the base snapshot's 459 tensors:

| Artifact | Verdict | Absent | Extra | Shape |
|---|---|---|---|---|
| saved by 5.3.0, quantized | pass | 0 | 0 | 0 |
| saved by 5.14.1, quantized | pass | 0 | 0 | 0 |
| saved by 5.4.0, quantized | fail | 96 | 96 | 0 |
| saved by 5.5.1, dequantize | fail | 96 | 48 | 48 |
| saved by 5.5.2, dequantize | fail | 96 | 2 | 0 |
| saved by 5.14.1, dequantize | fail | 96 | 2 | 0 |
| saved by 5.3.0, dequantize | fail | none written | none written | none written |
| saved by 5.4.0, dequantize | fail | none written | none written | none written |
| `p-e-w/gpt-oss-20b-heretic-ara-v4` | fail | 96 | 96 | 0 |

The absent and extra columns are names: absent counts names the source has that the artifact does not, and extra counts names the artifact has that the source does not. The shape counts tensors that appear under the same name in both the source and the artifact, with different dimensions, which means a loader finds exactly the name it expects and gets the wrong geometry behind it. The forty-eight on the 5.5.1 dequantize row are the expert blocks going from a four-dimensional `(32, 2880, 90, 16)` in the source to a three-dimensional `(32, 2880, 2880)` in the artifact, and the gate-up half from `(32, 5760, 90, 16)` to `(32, 2880, 5760)`. Shape is evaluated before names and always fails, since there is no reading under which a correctly named tensor with the wrong geometry is benign.

The two `none written` rows are the case where `save_pretrained` raises part way through, leaving `config.json` and `generation_config.json` and no weights at all, so there is nothing to count and nothing to compare. Those are the rows that only the trial save before optimization can catch, since a save that does not return never reaches a post-save check.

Interestingly enough, `tiny-random/gemma-3`, `hf-internal-testing/tiny-random-Qwen2VLForConditionalGeneration` and `OpenGVLab/InternVL3-1B-hf` fail to pass for a reason which is neither of the defects identified by me in https://github.com/p-e-w/heretic/pull/211#issuecomment-5094370390, which means that there are likely more bugs in transformers than previously believed, and the two I have previously identified might be only the tip of the iceberg.