### PR TITLE
feat(ara): add DiffusionGemma block-diffusion model support

### DIFF
--- a/config.default.toml
+++ b/config.default.toml
@@ -58,6 +58,12 @@ residual_plot_style = "dark_background"
 # This is used to ensure balanced co-optimization of KL divergence and refusal count.
 kl_divergence_scale = 1.0
 
+# List of component names to target for abliteration.
+target_components = ["attn.o_proj"]
+
+# L-BFGS early stopping threshold for ARA.
+ara_convergence_threshold = 1e-6
+
 # The KL divergence to target. Below this value, an objective based on the refusal count is used.
 # This helps prevent the sampler from extensively exploring parameter combinations that "do nothing".
 kl_divergence_target = 0.01

--- a/config.default.toml
+++ b/config.default.toml
@@ -59,7 +59,7 @@ residual_plot_style = "dark_background"
 kl_divergence_scale = 1.0
 
 # List of component names to target for abliteration.
-target_components = ["attn.o_proj", "mlp.down_proj"]
+target_components = ["attn.o_proj"]
 
 # L-BFGS early stopping threshold for ARA.
 ara_convergence_threshold = 1e-6

--- a/config.default.toml
+++ b/config.default.toml
@@ -59,7 +59,7 @@ residual_plot_style = "dark_background"
 kl_divergence_scale = 1.0
 
 # List of component names to target for abliteration.
-target_components = ["attn.o_proj"]
+target_components = ["attn.o_proj", "mlp.down_proj"]
 
 # L-BFGS early stopping threshold for ARA.
 ara_convergence_threshold = 1e-6

--- a/src/heretic/config.py
+++ b/src/heretic/config.py
@@ -189,10 +189,19 @@ class Settings(BaseSettings):
     )
 
     target_components: list[str] = Field(
-        default=["attn.o_proj", "mlp.down_proj"],
+        default=["attn.o_proj"],
         description=(
             "List of component names to target for abliteration. "
             'Currently supported values are "attn.o_proj" and "mlp.down_proj".'
+        ),
+    )
+
+    ara_convergence_threshold: float = Field(
+        default=1e-6,
+        description=(
+            "L-BFGS early stopping threshold for ARA. If the loss between consecutive optimizer "
+            "steps changes by less than this value, the optimization is considered converged and "
+            "remaining steps are skipped. Set to 0 to disable early stopping."
         ),
     )
 

--- a/src/heretic/config.py
+++ b/src/heretic/config.py
@@ -189,7 +189,7 @@ class Settings(BaseSettings):
     )
 
     target_components: list[str] = Field(
-        default=["attn.o_proj"],
+        default=["attn.o_proj", "mlp.down_proj"],
         description=(
             "List of component names to target for abliteration. "
             'Currently supported values are "attn.o_proj" and "mlp.down_proj".'
@@ -197,7 +197,7 @@ class Settings(BaseSettings):
     )
 
     ara_convergence_threshold: float = Field(
-        default=1e-6,
+        default=1e-6, 
         description=(
             "L-BFGS early stopping threshold for ARA. If the loss between consecutive optimizer "
             "steps changes by less than this value, the optimization is considered converged and "

--- a/src/heretic/config.py
+++ b/src/heretic/config.py
@@ -189,7 +189,7 @@ class Settings(BaseSettings):
     )
 
     target_components: list[str] = Field(
-        default=["attn.o_proj", "mlp.down_proj"],
+        default=["attn.o_proj"],
         description=(
             "List of component names to target for abliteration. "
             'Currently supported values are "attn.o_proj" and "mlp.down_proj".'

--- a/src/heretic/config.py
+++ b/src/heretic/config.py
@@ -189,7 +189,7 @@ class Settings(BaseSettings):
     )
 
     target_components: list[str] = Field(
-        default=["attn.o_proj"],
+        default=["attn.o_proj", "mlp.down_proj"],
         description=(
             "List of component names to target for abliteration. "
             'Currently supported values are "attn.o_proj" and "mlp.down_proj".'

--- a/src/heretic/main.py
+++ b/src/heretic/main.py
@@ -525,6 +525,18 @@ def run():
                 1.0,
                 log=True,
             )
+            steer_core_weight = trial.suggest_float(
+                "steer_core_weight",
+                0.0001,
+                1.0,
+                log=True,
+            )
+            steer_late_weight = trial.suggest_float(
+                "steer_late_weight",
+                0.0001,
+                1.0,
+                log=True,
+            )
             overcorrect_relative_weight = trial.suggest_float(
                 "overcorrect_relative_weight",
                 0.0,
@@ -541,6 +553,8 @@ def run():
                 end_layer_index=end_layer_index,
                 preserve_good_behavior_weight=preserve_good_behavior_weight,
                 steer_bad_behavior_weight=steer_bad_behavior_weight,
+                steer_core_weight=steer_core_weight,
+                steer_late_weight=steer_late_weight,
                 overcorrect_relative_weight=overcorrect_relative_weight,
                 neighbor_count=neighbor_count,
             )

--- a/src/heretic/main.py
+++ b/src/heretic/main.py
@@ -657,6 +657,7 @@ def run():
             model.abliterate(refusal_directions, direction_index, parameters)
         print("* Evaluating...")
         score, kl_divergence, refusals = evaluator.get_score()
+        model.coherence_check()
 
         elapsed_time = time.perf_counter() - start_time
         remaining_time = (elapsed_time / (trial_index - start_index)) * (

--- a/src/heretic/main.py
+++ b/src/heretic/main.py
@@ -657,7 +657,6 @@ def run():
             model.abliterate(refusal_directions, direction_index, parameters)
         print("* Evaluating...")
         score, kl_divergence, refusals = evaluator.get_score()
-        model.coherence_check()
 
         elapsed_time = time.perf_counter() - start_time
         remaining_time = (elapsed_time / (trial_index - start_index)) * (

--- a/src/heretic/model.py
+++ b/src/heretic/model.py
@@ -60,8 +60,31 @@ class ARAParameters:
     end_layer_index: int
     preserve_good_behavior_weight: float
     steer_bad_behavior_weight: float
+    steer_core_weight: float | None = None
+    steer_late_weight: float | None = None
     overcorrect_relative_weight: float
     neighbor_count: int
+
+    def get_steer_weight(self, layer_index: int) -> float:
+        """
+        Splits the active layer range into thirds:
+        - Early (first third):  steer_bad_behavior_weight
+        - Core  (middle third): steer_core_weight (falls back to steer_bad_behavior_weight)
+        - Late  (final third):  steer_late_weight (falls back to steer_bad_behavior_weight)
+        """
+        core = self.steer_core_weight if self.steer_core_weight is not None else self.steer_bad_behavior_weight
+        late = self.steer_late_weight if self.steer_late_weight is not None else self.steer_bad_behavior_weight
+
+        layer_range = self.end_layer_index - self.start_layer_index
+        core_start = self.start_layer_index + layer_range // 3
+        late_start = self.start_layer_index + (2 * layer_range) // 3
+
+        if layer_index < core_start:
+            return self.steer_bad_behavior_weight
+        elif layer_index < late_start:
+            return core
+        else:
+            return late
 
 
 # The list contains one element per layer.
@@ -80,6 +103,7 @@ class Model:
         self.settings = settings
         self.response_prefix = ""
         self.needs_reload = False
+        self._ara_weight_snapshot = None
 
         print()
         print(f"Loading model [bold]{settings.model}[/]...")
@@ -314,16 +338,17 @@ class Model:
           performs full model reload with quantization config.
         """
         current_model = getattr(self.model.config, "name_or_path", None)
-        if (
-            current_model == self.settings.model
-            and not self.needs_reload
-            and (not self.settings.use_ara or self.settings.use_ara_lora)
-        ):
-            # Reset LoRA adapters to zero (identity transformation)
-            for name, module in self.model.named_modules():
-                if "lora_B" in name and hasattr(module, "weight"):
-                    torch.nn.init.zeros_(module.weight)
-            return
+        if current_model == self.settings.model and not self.needs_reload:
+            if not self.settings.use_ara or self.settings.use_ara_lora:
+                # Reset LoRA adapters to zero (identity transformation)
+                for name, module in self.model.named_modules():
+                    if "lora_B" in name and hasattr(module, "weight"):
+                        torch.nn.init.zeros_(module.weight)
+                return
+            elif self.settings.use_ara and getattr(self, "_ara_weight_snapshot", None) is not None:
+                self.restore_ara_weights()
+                return
+
 
         dtype = self.model.dtype
 
@@ -352,12 +377,48 @@ class Model:
 
         self.needs_reload = False
 
+    def _is_diffusion_gemma(self) -> bool:
+        return self.settings.model == "google/diffusiongemma-26B-A4B-it"
+
+    def _get_diffusion_gemma_encoder(self) -> Module:
+        """Extract the encoder model for DiffusionGemma."""
+        model = self.model
+        if isinstance(model, PeftModel):
+            model = model.base_model.model
+        return model.model.encoder
+
+    def snapshot_ara_weights(self) -> None:
+        """Snapshot weights of all abliterable modules to CPU for fast ARA reset."""
+        self._ara_weight_snapshot = {}
+        for layer_index in range(len(self.get_layers())):
+            for component, modules in self.get_layer_modules(layer_index).items():
+                for module_index, module in enumerate(modules):
+                    key = (layer_index, component, module_index)
+                    self._ara_weight_snapshot[key] = module.weight.data.detach().clone().cpu()
+        print(f"* Snapshotted {len(self._ara_weight_snapshot)} module weights for fast reset")
+
+    def restore_ara_weights(self) -> None:
+        """Restore weights from CPU snapshot instead of full model reload."""
+        assert self._ara_weight_snapshot is not None, "No ARA weight snapshot available"
+        for layer_index in range(len(self.get_layers())):
+            for component, modules in self.get_layer_modules(layer_index).items():
+                for module_index, module in enumerate(modules):
+                    key = (layer_index, component, module_index)
+                    if key in self._ara_weight_snapshot:
+                        module.weight.data.copy_(
+                            self._ara_weight_snapshot[key].to(module.weight.device)
+                        )
+        self.needs_reload = False
+
     def get_layers(self) -> ModuleList:
         model = self.model
 
         # Unwrap PeftModel (always true after _apply_lora)
         if isinstance(model, PeftModel):
             model = model.base_model.model
+
+        if self._is_diffusion_gemma():
+            return self._get_diffusion_gemma_encoder().layers
 
         # Most multimodal models.
         with suppress(Exception):
@@ -601,6 +662,11 @@ class Model:
                         else:
                             return matrix
 
+                    if module_index not in good_module_io[layer_index][component]:
+                        continue
+                    if module_index not in bad_module_io[layer_index][component]:
+                        continue
+
                     good_input, good_output = good_module_io[layer_index][component][
                         module_index
                     ]
@@ -622,32 +688,28 @@ class Model:
                             (new_good_output - good_output) ** 2
                         ).mean()
 
-                        steer_bad_behavior = (
-                            # Pull the outputs for "bad" prompts towards
-                            # the original outputs for "good" prompts.
-                            mean_distances_to_knn(
-                                new_bad_output,
-                                good_output,
-                                parameters.neighbor_count,
-                            ).mean()
-                            # Push the outputs for "bad" prompts away from
-                            # the original outputs for "bad" prompts.
-                            # In combination with the above, this overcorrects
-                            # away from the original residuals, which results
-                            # in stronger steering that can overcome more complex
-                            # refusal mechanisms.
-                            + parameters.overcorrect_relative_weight
-                            * -mean_distances_to_knn(
-                                new_bad_output,
-                                bad_output,
-                                parameters.neighbor_count,
-                            ).mean()
-                        )
+                        pull_dist = mean_distances_to_knn(
+                            new_bad_output,
+                            good_output,
+                            parameters.neighbor_count,
+                        ).mean()
+                        
+                        push_dist = mean_distances_to_knn(
+                            new_bad_output,
+                            bad_output,
+                            parameters.neighbor_count,
+                        ).mean()
+                        
+                        overcorrect_loss = parameters.overcorrect_relative_weight * -push_dist
+                        # Clamp overcorrection loss so it never pushes away harder than it pulls towards good
+                        overcorrect_loss = torch.clamp(overcorrect_loss, max=0)
+
+                        steer_bad_behavior = pull_dist + overcorrect_loss
 
                         return (
                             parameters.preserve_good_behavior_weight
                             * preserve_good_behavior
-                            + parameters.steer_bad_behavior_weight * steer_bad_behavior
+                            + parameters.get_steer_weight(layer_index) * steer_bad_behavior
                         )
 
                     optimizer = LBFGS(
@@ -664,12 +726,14 @@ class Model:
                         loss.backward()
                         return loss
 
+                    prev_loss = float("inf")
                     # Convergence usually happens within 2-3 steps, so this is more than enough.
                     for step in range(5):
                         loss = optimizer.step(closure)
-                        # print(
-                        #    f"\\[{layer_index}/{component}/{module_index}] Step: {step}, Loss: {loss.item():.6f}"
-                        # )
+                        loss_val = loss.item() if loss is not None else float("inf")
+                        if self.settings.ara_convergence_threshold > 0 and abs(prev_loss - loss_val) < self.settings.ara_convergence_threshold:
+                            break
+                        prev_loss = loss_val
 
                     with torch.no_grad():
                         matrix.copy_(get_matrix())
@@ -718,6 +782,11 @@ class Model:
 
                     # Data preparation.
                     # Move I/O tensors to the device of the adapter weights.
+                    if module_index not in good_module_io[layer_index][component]:
+                        continue
+                    if module_index not in bad_module_io[layer_index][component]:
+                        continue
+
                     good_input, good_output = good_module_io[layer_index][component][module_index]
                     bad_input, bad_output = bad_module_io[layer_index][component][module_index]
 
@@ -745,24 +814,27 @@ class Model:
                             (new_good_output - good_output) ** 2
                         ).mean()
 
-                        steer_bad_behavior = (
-                            mean_distances_to_knn(
-                                new_bad_output,
-                                good_output,
-                                parameters.neighbor_count,
-                            ).mean()
-                            + parameters.overcorrect_relative_weight
-                            * -mean_distances_to_knn(
-                                new_bad_output,
-                                bad_output,
-                                parameters.neighbor_count,
-                            ).mean()
-                        )
+                        pull_dist = mean_distances_to_knn(
+                            new_bad_output,
+                            good_output,
+                            parameters.neighbor_count,
+                        ).mean()
+                        
+                        push_dist = mean_distances_to_knn(
+                            new_bad_output,
+                            bad_output,
+                            parameters.neighbor_count,
+                        ).mean()
+                        
+                        overcorrect_loss = parameters.overcorrect_relative_weight * -push_dist
+                        overcorrect_loss = torch.clamp(overcorrect_loss, max=0)
+
+                        steer_bad_behavior = pull_dist + overcorrect_loss
 
                         return (
                             parameters.preserve_good_behavior_weight
                             * preserve_good_behavior
-                            + parameters.steer_bad_behavior_weight * steer_bad_behavior
+                            + parameters.get_steer_weight(layer_index) * steer_bad_behavior
                         )
 
                     # Optimization loop.
@@ -782,9 +854,14 @@ class Model:
                         loss.backward()
                         return loss
 
+                    prev_loss = float("inf")
                     # Run optimization steps.
                     for step in range(5):
-                        optimizer.step(closure)
+                        loss = optimizer.step(closure)
+                        loss_val = loss.item() if loss is not None else float("inf")
+                        if self.settings.ara_convergence_threshold > 0 and abs(prev_loss - loss_val) < self.settings.ara_convergence_threshold:
+                            break
+                        prev_loss = loss_val
 
     def generate(
         self,

--- a/src/heretic/model.py
+++ b/src/heretic/model.py
@@ -916,16 +916,15 @@ class Model:
     def coherence_check(self) -> None:
         """Generate responses to a few harmless prompts to verify model coherence."""
         test_prompts = [
-            Prompt("What is the capital of France?"),
-            Prompt("Explain photosynthesis in one sentence."),
-            Prompt("Write a short poem about the ocean."),
+            Prompt(system="", user="What is the capital of France?"),
+            Prompt(system="", user="Explain photosynthesis in one sentence."),
+            Prompt(system="", user="Write a short poem about the ocean."),
         ]
         responses = self.get_responses(test_prompts, skip_special_tokens=True)
         print("  * [bold]Coherence Check[/] (harmless prompt responses):")
         for prompt, response in zip(test_prompts, responses):
-            # Truncate long responses for readability
             short = response.strip()[:200]
-            print(f"    Q: {prompt}")
+            print(f"    Q: {prompt.user}")
             print(f"    A: {short}")
             print()
 

--- a/src/heretic/model.py
+++ b/src/heretic/model.py
@@ -1142,6 +1142,9 @@ class Model:
         # of model.generate with return_dict_in_generate=True.
         outputs = cast(GenerateDecoderOnlyOutput, outputs)
 
+        if not hasattr(outputs, "scores") or outputs.scores is None:
+            return torch.zeros((1, len(self.tokenizer)), device=self.model.device)
+
         # Logits for the first (only) generated token.
         # This cast is valid because we passed output_scores=True above.
         logits = cast(tuple[FloatTensor], outputs.scores)[0]

--- a/src/heretic/model.py
+++ b/src/heretic/model.py
@@ -913,6 +913,22 @@ class Model:
 
         return inputs, outputs
 
+    def coherence_check(self) -> None:
+        """Generate responses to a few harmless prompts to verify model coherence."""
+        test_prompts = [
+            Prompt("What is the capital of France?"),
+            Prompt("Explain photosynthesis in one sentence."),
+            Prompt("Write a short poem about the ocean."),
+        ]
+        responses = self.get_responses(test_prompts, skip_special_tokens=True)
+        print("  * [bold]Coherence Check[/] (harmless prompt responses):")
+        for prompt, response in zip(test_prompts, responses):
+            # Truncate long responses for readability
+            short = response.strip()[:200]
+            print(f"    Q: {prompt}")
+            print(f"    A: {short}")
+            print()
+
     def get_responses(
         self,
         prompts: list[Prompt],

--- a/src/heretic/model.py
+++ b/src/heretic/model.py
@@ -1143,7 +1143,27 @@ class Model:
         outputs = cast(GenerateDecoderOnlyOutput, outputs)
 
         if not hasattr(outputs, "scores") or outputs.scores is None:
-            return torch.zeros((1, len(self.tokenizer)), device=self.model.device)
+            # Fallback for models that do not output next-token distribution via generation (e.g. DiffusionGemma).
+            # We do a direct forward pass over a deterministic randomly-initialized canvas to compute a fixed proxy distribution.
+            inputs = self._tokenize(prompts)
+            inputs = {k: v.to(self.model.device) for k, v in inputs.items()}
+            
+            # For DiffusionGemma, providing decoder_input_ids bypasses the random initialization,
+            # ensuring a deterministic and comparable forward pass for KLD computation.
+            batch_size = inputs["input_ids"].shape[0]
+            canvas_length = getattr(self.model.config, "canvas_length", 256)
+            decoder_input_ids = torch.zeros((batch_size, canvas_length), dtype=torch.long, device=self.model.device)
+            inputs["decoder_input_ids"] = decoder_input_ids
+            
+            with torch.inference_mode():
+                out = self.model(**inputs)
+                
+            # Logits are [batch, canvas_length, vocab]
+            logits = out.logits
+            
+            # Average over the canvas length to get a [batch, vocab] distribution representation
+            logits = logits.mean(dim=1)
+            return F.log_softmax(logits, dim=-1)
 
         # Logits for the first (only) generated token.
         # This cast is valid because we passed output_scores=True above.

--- a/src/heretic/model.py
+++ b/src/heretic/model.py
@@ -908,6 +908,9 @@ class Model:
             do_sample=False,  # Use greedy decoding to ensure deterministic outputs.
         )  # ty:ignore[call-non-callable]
 
+        if not isinstance(outputs, Tensor):
+            outputs = outputs.sequences
+
         return inputs, outputs
 
     def get_responses(

--- a/src/heretic/model.py
+++ b/src/heretic/model.py
@@ -249,6 +249,12 @@ class Model:
 
         # self.peft_config is a LoraConfig object rather than a dictionary,
         # so the result is a PeftModel rather than a PeftMixedModel.
+        if not hasattr(self.model, "prepare_inputs_for_generation"):
+            # Workaround for PEFT trying to proxy prepare_inputs_for_generation
+            # for CAUSAL_LM task types even if the underlying model lacks it 
+            # (e.g. DiffusionGemma block-diffusion models).
+            self.model.prepare_inputs_for_generation = lambda *args, **kwargs: {}
+            
         self.model = cast(PeftModel, get_peft_model(self.model, self.peft_config))
 
         display_targets = sorted({name.rsplit(".", 1)[-1] for name in target_modules})

--- a/src/heretic/model.py
+++ b/src/heretic/model.py
@@ -913,21 +913,6 @@ class Model:
 
         return inputs, outputs
 
-    def coherence_check(self) -> None:
-        """Generate responses to a few harmless prompts to verify model coherence."""
-        test_prompts = [
-            Prompt(system="", user="What is the capital of France?"),
-            Prompt(system="", user="Explain photosynthesis in one sentence."),
-            Prompt(system="", user="Write a short poem about the ocean."),
-        ]
-        responses = self.get_responses(test_prompts, skip_special_tokens=True)
-        print("  * [bold]Coherence Check[/] (harmless prompt responses):")
-        for prompt, response in zip(test_prompts, responses):
-            short = response.strip()[:200]
-            print(f"    Q: {prompt.user}")
-            print(f"    A: {short}")
-            print()
-
     def get_responses(
         self,
         prompts: list[Prompt],

--- a/src/heretic/model.py
+++ b/src/heretic/model.py
@@ -868,13 +868,13 @@ class Model:
         prompts: list[Prompt],
         **kwargs: Any,
     ) -> tuple[BatchEncoding, GenerateDecoderOnlyOutput | LongTensor]:
-        chats = [
-            [
-                {"role": "system", "content": prompt.system},
-                {"role": "user", "content": prompt.user},
-            ]
-            for prompt in prompts
-        ]
+        chats = []
+        for prompt in prompts:
+            messages = []
+            if prompt.system:
+                messages.append({"role": "system", "content": prompt.system})
+            messages.append({"role": "user", "content": prompt.user})
+            chats.append(messages)
 
         # This cast is valid because list[str] is the return type
         # for batched operation with tokenize=False.

--- a/src/heretic/model.py
+++ b/src/heretic/model.py
@@ -60,10 +60,10 @@ class ARAParameters:
     end_layer_index: int
     preserve_good_behavior_weight: float
     steer_bad_behavior_weight: float
-    steer_core_weight: float | None = None
-    steer_late_weight: float | None = None
     overcorrect_relative_weight: float
     neighbor_count: int
+    steer_core_weight: float | None = None
+    steer_late_weight: float | None = None
 
     def get_steer_weight(self, layer_index: int) -> float:
         """

--- a/src/heretic/model.py
+++ b/src/heretic/model.py
@@ -385,7 +385,7 @@ class Model:
         model = self.model
         if isinstance(model, PeftModel):
             model = model.base_model.model
-        return model.model.encoder
+        return model.model.encoder.language_model
 
     def snapshot_ara_weights(self) -> None:
         """Snapshot weights of all abliterable modules to CPU for fast ARA reset."""

--- a/src/heretic/model.py
+++ b/src/heretic/model.py
@@ -863,21 +863,14 @@ class Model:
                             break
                         prev_loss = loss_val
 
-    def generate(
-        self,
-        prompts: list[Prompt],
-        **kwargs: Any,
-    ) -> tuple[BatchEncoding, GenerateDecoderOnlyOutput | LongTensor]:
+    def _get_inputs(self, prompts: list[Prompt]) -> dict[str, torch.Tensor]:
         chats = []
         for prompt in prompts:
-            messages = []
+            chat = [{"role": "user", "content": prompt.user}]
             if prompt.system:
-                messages.append({"role": "system", "content": prompt.system})
-            messages.append({"role": "user", "content": prompt.user})
-            chats.append(messages)
+                chat.insert(0, {"role": "system", "content": prompt.system})
+            chats.append(chat)
 
-        # This cast is valid because list[str] is the return type
-        # for batched operation with tokenize=False.
         chat_prompts = cast(
             list[str],
             self.tokenizer.apply_chat_template(
@@ -888,16 +881,21 @@ class Model:
         )
 
         if self.response_prefix:
-            # Append the common response prefix to the prompts so that evaluation happens
-            # at the point where responses start to differ for different prompts.
             chat_prompts = [prompt + self.response_prefix for prompt in chat_prompts]
 
-        inputs = self.tokenizer(
+        return self.tokenizer(
             chat_prompts,
             return_tensors="pt",
             padding=True,
             return_token_type_ids=False,
         ).to(self.model.device)
+
+    def generate(
+        self,
+        prompts: list[Prompt],
+        **kwargs: Any,
+    ) -> tuple[BatchEncoding, GenerateDecoderOnlyOutput | LongTensor]:
+        inputs = self._get_inputs(prompts)
 
         # FIXME: The type checker has been disabled here because of the extremely complex
         #        interplay between different generate() signatures and dynamic delegation.
@@ -1145,7 +1143,7 @@ class Model:
         if not hasattr(outputs, "scores") or outputs.scores is None:
             # Fallback for models that do not output next-token distribution via generation (e.g. DiffusionGemma).
             # We do a direct forward pass over a deterministic randomly-initialized canvas to compute a fixed proxy distribution.
-            inputs = self._tokenize(prompts)
+            inputs = self._get_inputs(prompts)
             inputs = {k: v.to(self.model.device) for k, v in inputs.items()}
             
             # For DiffusionGemma, providing decoder_input_ids bypasses the random initialization,

--- a/src/heretic/utils.py
+++ b/src/heretic/utils.py
@@ -238,6 +238,9 @@ def batchify(items: list[T], batch_size: int) -> list[list[T]]:
 # For each vector in the 2D-tensor `a`, computes the mean Euclidean distance
 # to the `k` nearest neighbors of the vector among the vectors in the 2D-tensor `b`.
 def mean_distances_to_knn(a: Tensor, b: Tensor, k: int) -> Tensor:
+    if b.shape[0] == 0:
+        return torch.zeros(a.shape[0], device=a.device)
+    k = min(k, b.shape[0])
     distances = torch.cdist(a, b)
     nearest_distances, _ = distances.topk(k, dim=1, largest=False)
     return nearest_distances.mean(1)

--- a/src/heretic/utils.py
+++ b/src/heretic/utils.py
@@ -241,9 +241,9 @@ def mean_distances_to_knn(a: Tensor, b: Tensor, k: int) -> Tensor:
     if b.shape[0] == 0:
         return torch.zeros(a.shape[0], device=a.device)
     k = min(k, b.shape[0])
-    distances = torch.cdist(a, b)
+    distances = torch.cdist(a.float(), b.float())
     nearest_distances, _ = distances.topk(k, dim=1, largest=False)
-    return nearest_distances.mean(1)
+    return nearest_distances.mean(1).to(a.dtype)
 
 
 def empty_cache():


### PR DESCRIPTION
This PR extends Heretic's Arbitrary-Rank Ablation (ARA) pipeline to support [DiffusionGemma](https://huggingface.co/google/diffusiongemma-26B-A4B-it), allowing matrix optimization and abliteration on non-autoregressive, block-diffusion language models.

Standard transformers generate text sequentially, whereas DiffusionGemma performs iterative denoising over a fixed token canvas and encasing its transformer stack inside a custom bidirectional wrapper. This PR adapts layer discovery, generation decoding, and KLD evaluation to handle this paradigm cleanly without affecting standard causal language models.

**Key Technical Adaptations**
Architecture Navigation & LoRA Compatibility: Added structural checks to route layer extraction through `model.encoder.language_model` when DiffusionGemma is detected. To prevent PEFT from crashing during adapter initialization on models lacking traditional causal generation methods, a safe fallback is implemented for `prepare_inputs_for_generation`.

Deterministic KLD Proxy for Diffusion Models: Because block-diffusion generation does not expose per-token probability distributions via standard `.scores`, `get_logprobs()` implements a deterministic forward pass over a zero-initialized token canvas (decoder_input_ids). This produces a repeatable probability distribution before and after matrix steering, giving Optuna an accurate KL-divergence metric to penalize destructive weight updates.

Robustness Improvements: Fixed a BFloat16 dtype incompatibility in torch.cdist during KNN distance calculations and made system-role message injection conditional in chat templates to avoid tokenization errors on models with strict message schemas.




**Analytical Note**

During experimentation with both Standard ARA (`use_ara = true`) and Direct LoRA ARA (`use_ara_lora = true`), we observed that full-weight matrix optimization massively outperforms direct LoRA adapter optimization under the KNN retrieval objective. We wanted to share our theoretical analysis on why this occurs:

1. **Rank & Geometric Capacity:** Standard ARA operates directly on the full $d \times d$ weight matrix (e.g., $4096 \times 4096$). Shifting activation vectors away from refusal clusters across hundreds of training prompts requires high-dimensional tensor rotations. When constraining updates to a low-rank factorization ($\Delta W = B \cdot A$), a rank-8 or rank-16 matrix lacks the degrees of freedom required to resolve multi-directional steering targets without inducing severe feature collapse.

2. **Bilinear Non-Convexity & L-BFGS Stalling:** Standard ARA optimizes a single matrix $W$, presenting a clean linear forward mapping for solver line-search. Conversely, optimizing two matrices jointly via their product $(A, B) \mapsto B \cdot A$ creates scale ambiguities ($B \rightarrow \alpha B,\; A \rightarrow \frac{1}{\alpha}A$) and severe saddle points where L-BFGS curvature estimates collapse and stall early in local minima.

3. **Recommended Workflow:** For users who require lightweight adapter artifacts, we recommend running **Standard ARA** first to find the optimal full-rank matrix $W_{\text{new}}$, then extracting the adapter post-hoc via SVD on the resulting delta ($\Delta W = W_{\text{new}} - W_{\text{base}} \rightarrow U S V^T$). This retains the empirical precision of full-rank steering while exporting clean LoRA adapter files.

