### PR TITLE
fix(ara): free gradient buffers after optimization

### DIFF
--- a/src/heretic/model.py
+++ b/src/heretic/model.py
@@ -671,6 +671,13 @@ class Model:
                         #    f"\\[{layer_index}/{component}/{module_index}] Step: {step}, Loss: {loss.item():.6f}"
                         # )
 
+                    # Free the gradient buffers accumulated on the weight parameters
+                    # during optimization. Without this, they persist on the model
+                    # (one full-size gradient per processed weight) and can easily
+                    # consume tens of GiB of VRAM, causing out-of-memory errors
+                    # during the subsequent evaluation.
+                    optimizer.zero_grad(set_to_none=True)
+
                     with torch.no_grad():
                         matrix.copy_(get_matrix())
 
@@ -785,6 +792,10 @@ class Model:
                     # Run optimization steps.
                     for step in range(5):
                         optimizer.step(closure)
+
+                    # Free the gradient buffers accumulated on the LoRA adapter
+                    # parameters during optimization (see ara_abliterate for details).
+                    optimizer.zero_grad(set_to_none=True)
 
     def generate(
         self,


### PR DESCRIPTION
LBFGS leaves a full-size gradient buffer on every optimized weight. Across the layers in a typical trial this is many GiB of VRAM that persists into evaluation, causing CUDA out-of-memory errors. Clear the gradients after each module is optimized.