### PR TITLE
fix: improve dtype fallback error reporting

### DIFF
--- a/src/heretic/model.py
+++ b/src/heretic/model.py
@@ -105,68 +105,7 @@ class Model:
 
         self.trusted_models = set()
 
-        for dtype in settings.dtypes:
-            print(f"* Trying dtype [bold]{dtype}[/]...")
-
-            try:
-                quantization_config = self._get_quantization_config(dtype)
-
-                extra_kwargs = {}
-                # Only include quantization_config if it's not None
-                # (some models like gpt-oss have issues with explicit None).
-                if quantization_config is not None:
-                    extra_kwargs["quantization_config"] = quantization_config
-
-                self.model = get_model_class(settings.model).from_pretrained(
-                    settings.model,
-                    dtype=dtype,
-                    device_map=settings.device_map,
-                    max_memory=self.max_memory,
-                    trust_remote_code=True
-                    if settings.model in self.trusted_models
-                    else None,
-                    **self.revision_kwargs,
-                    **extra_kwargs,
-                )
-
-                self.dtype = self.model.dtype
-
-                # If we reach this point and the model requires trust_remote_code,
-                # the user must have agreed when prompted to execute remote code,
-                # because from_pretrained raises an exception otherwise.
-                self.trusted_models.add(settings.model)
-
-                # A test run can reveal dtype-related problems such as the infamous
-                # "RuntimeError: probability tensor contains either `inf`, `nan` or element < 0"
-                # (https://github.com/meta-llama/llama/issues/380).
-                self.generate(
-                    [
-                        Prompt(
-                            system=settings.system_prompt,
-                            user="What is 1+1?",
-                        )
-                    ],
-                    max_new_tokens=1,
-                )
-            except Exception as error:
-                self.model = None  # ty:ignore[invalid-assignment]
-                empty_cache()
-
-                formatted = format_exception(error)
-                if "\n" in formatted:
-                    print(f"* [red]Failed:\n{formatted}[/]")
-                else:
-                    print(f"* [red]Failed ({formatted})[/]")
-
-                continue
-
-            if settings.quantization == QuantizationMethod.BNB_4BIT:
-                print("* Quantized to 4-bit precision")
-
-            break
-
-        if self.model is None:
-            raise Exception("Failed to load model with all configured dtypes.")
+        self._load_model_with_dtype_fallback()
 
         self._apply_lora()
 
@@ -237,6 +176,77 @@ class Model:
         print(
             f"* LoRA adapters initialized (target types: {', '.join(display_targets)})"
         )
+
+    def _load_model_with_dtype_fallback(self) -> None:
+        failures: list[tuple[str, str]] = []
+
+        for dtype in self.settings.dtypes:
+            print(f"* Trying dtype [bold]{dtype}[/]...")
+
+            try:
+                quantization_config = self._get_quantization_config(dtype)
+
+                extra_kwargs = {}
+                # Only include quantization_config if it's not None
+                # (some models like gpt-oss have issues with explicit None).
+                if quantization_config is not None:
+                    extra_kwargs["quantization_config"] = quantization_config
+
+                self.model = get_model_class(self.settings.model).from_pretrained(
+                    self.settings.model,
+                    dtype=dtype,
+                    device_map=self.settings.device_map,
+                    max_memory=self.max_memory,
+                    trust_remote_code=True
+                    if self.settings.model in self.trusted_models
+                    else None,
+                    **self.revision_kwargs,
+                    **extra_kwargs,
+                )
+
+                self.dtype = self.model.dtype
+
+                # If we reach this point and the model requires trust_remote_code,
+                # the user must have agreed when prompted to execute remote code,
+                # because from_pretrained raises an exception otherwise.
+                self.trusted_models.add(self.settings.model)
+
+                # A test run can reveal dtype-related problems such as the infamous
+                # "RuntimeError: probability tensor contains either `inf`, `nan` or element < 0"
+                # (https://github.com/meta-llama/llama/issues/380).
+                self.generate(
+                    [
+                        Prompt(
+                            system=self.settings.system_prompt,
+                            user="What is 1+1?",
+                        )
+                    ],
+                    max_new_tokens=1,
+                )
+            except Exception as error:
+                self.model = None  # ty:ignore[invalid-assignment]
+                empty_cache()
+
+                formatted = format_exception(error)
+                failures.append((dtype, formatted))
+
+                if "\n" in formatted:
+                    print(f"* [red]Failed:\n{formatted}[/]")
+                else:
+                    print(f"* [red]Failed ({formatted})[/]")
+
+                continue
+
+            if self.settings.quantization == QuantizationMethod.BNB_4BIT:
+                print("* Quantized to 4-bit precision")
+
+            break
+
+        if self.model is None:
+            details = "\n".join(f"- {dtype}: {reason}" for dtype, reason in failures)
+            raise Exception(
+                "Failed to load model with all configured dtypes:\n" + details
+            )
 
     def _get_quantization_config(self, dtype: str) -> BitsAndBytesConfig | None:
         """

--- a/tests/test_model_loading.py
+++ b/tests/test_model_loading.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2025-2026  Philipp Emanuel Weidmann <pew@worldwidemann.com> + contributors
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import torch
+
+from heretic.config import QuantizationMethod
+from heretic.model import Model
+
+
+def make_model_for_loading_test(dtypes: list[str]) -> Model:
+    model = Model.__new__(Model)
+    model.settings = SimpleNamespace(
+        dtypes=dtypes,
+        model="test-model",
+        quantization=QuantizationMethod.NONE,
+        device_map=None,
+        system_prompt="",
+    )
+    model.max_memory = None
+    model.revision_kwargs = {}
+    model.trusted_models = set()
+    model.model = None
+    model._get_quantization_config = Mock(return_value=None)
+    model.generate = Mock()
+    return model
+
+
+class ModelLoadingTests(unittest.TestCase):
+    def test_reports_each_dtype_failure_and_clears_cache(self) -> None:
+        model = make_model_for_loading_test(["auto", "float16"])
+        model_class = Mock()
+        model_class.from_pretrained.side_effect = [
+            ValueError("auto is unsupported"),
+            RuntimeError("float16 ran out of memory"),
+        ]
+
+        with (
+            patch("heretic.model.get_model_class", return_value=model_class),
+            patch("heretic.model.empty_cache") as empty_cache,
+        ):
+            with self.assertRaises(Exception) as raised:
+                model._load_model_with_dtype_fallback()
+
+        message = str(raised.exception)
+        self.assertIn("auto: auto is unsupported", message)
+        self.assertIn("float16: float16 ran out of memory", message)
+        self.assertEqual(empty_cache.call_count, 2)
+        self.assertIsNone(model.model)
+
+    def test_continues_to_next_dtype_after_failure(self) -> None:
+        model = make_model_for_loading_test(["auto", "float16"])
+        model_class = Mock()
+        loaded_model = SimpleNamespace(dtype=torch.float16)
+        model_class.from_pretrained.side_effect = [
+            ValueError("auto is unsupported"),
+            loaded_model,
+        ]
+
+        with (
+            patch("heretic.model.get_model_class", return_value=model_class),
+            patch("heretic.model.empty_cache") as empty_cache,
+        ):
+            model._load_model_with_dtype_fallback()
+
+        self.assertIs(model.model, loaded_model)
+        self.assertEqual(model.dtype, torch.float16)
+        self.assertEqual(empty_cache.call_count, 1)
+        self.assertEqual(
+            [
+                call.kwargs["dtype"]
+                for call in model_class.from_pretrained.call_args_list
+            ],
+            ["auto", "float16"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #147\n\nModel loading still tries configured dtypes in order, but now records each failed dtype and its formatted reason. If all attempts fail, the final exception includes the ordered diagnostics. Cache cleanup remains on every failed attempt, with regression tests covering both fallback continuation and aggregate failure reporting.\n\nTests: python -m unittest discover -s tests -p "test_*.py"; ruff check; ruff format --check; ty check.