### PR TITLE
fix: stop retrying non-recoverable dtype errors

### DIFF
--- a/src/heretic/model.py
+++ b/src/heretic/model.py
@@ -47,6 +47,33 @@ def get_model_class(
         return AutoModelForCausalLM
 
 
+NON_RETRYABLE_DTYPE_ERROR_MARKERS = (
+    "cannot be imported",
+    "has no attribute",
+    "is required by",
+    "model type should be one of",
+    "no module named",
+    "not a valid torch dtype",
+    "not supported",
+    "unexpected keyword argument 'dtype'",
+    "unknown dtype",
+    "unrecognized configuration class",
+    "unsupported",
+)
+
+
+def classify_dtype_load_error(error: Exception) -> str:
+    """Classify whether trying another dtype can plausibly recover the load."""
+    if isinstance(error, ImportError):
+        return "non-retryable"
+
+    message = format_exception(error).lower()
+    if any(marker in message for marker in NON_RETRYABLE_DTYPE_ERROR_MARKERS):
+        return "non-retryable"
+
+    return "retryable"
+
+
 @dataclass
 class AbliterationParameters:
     max_weight: float
@@ -105,6 +132,8 @@ class Model:
 
         self.trusted_models = set()
 
+        failures: list[tuple[str, str, str]] = []
+
         for dtype in settings.dtypes:
             print(f"* Trying dtype [bold]{dtype}[/]...")
 
@@ -153,10 +182,18 @@ class Model:
                 empty_cache()
 
                 formatted = format_exception(error)
+                failure_class = classify_dtype_load_error(error)
+                failures.append((dtype, failure_class, formatted))
                 if "\n" in formatted:
                     print(f"* [red]Failed:\n{formatted}[/]")
                 else:
                     print(f"* [red]Failed ({formatted})[/]")
+
+                if failure_class == "non-retryable":
+                    print(
+                        f"* [yellow]Stopping dtype fallback: {failure_class} error[/]"
+                    )
+                    break
 
                 continue
 
@@ -166,7 +203,13 @@ class Model:
             break
 
         if self.model is None:
-            raise Exception("Failed to load model with all configured dtypes.")
+            details = "\n".join(
+                f"- {dtype} [{failure_class}]: {reason}"
+                for dtype, failure_class, reason in failures
+            )
+            raise Exception(
+                "Failed to load model with all configured dtypes:\n" + details
+            )
 
         self._apply_lora()
 

--- a/tests/test_dtype_fallback.py
+++ b/tests/test_dtype_fallback.py
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2025-2026  Philipp Emanuel Weidmann <pew@worldwidemann.com> + contributors
+
+import unittest
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import Mock, patch
+
+import torch
+
+from heretic.config import QuantizationMethod, Settings
+from heretic.model import Model, classify_dtype_load_error
+
+
+def make_settings(dtypes: list[str]) -> SimpleNamespace:
+    return SimpleNamespace(
+        dtypes=dtypes,
+        model="test-model",
+        model_commit=None,
+        max_memory=None,
+        device_map=None,
+        system_prompt="",
+        quantization=QuantizationMethod.NONE,
+    )
+
+
+class DtypeFallbackTests(unittest.TestCase):
+    def test_classifies_non_retryable_and_retryable_errors(self) -> None:
+        self.assertEqual(
+            classify_dtype_load_error(ModuleNotFoundError("mamba_ssm")),
+            "non-retryable",
+        )
+        self.assertEqual(
+            classify_dtype_load_error(
+                ValueError("Unrecognized configuration class LlavaConfig")
+            ),
+            "non-retryable",
+        )
+        self.assertEqual(
+            classify_dtype_load_error(
+                AttributeError("module 'torch' has no attribute 'fp8'")
+            ),
+            "non-retryable",
+        )
+        self.assertEqual(
+            classify_dtype_load_error(RuntimeError("CUDA out of memory")),
+            "retryable",
+        )
+
+    def test_stops_after_non_retryable_error(self) -> None:
+        tokenizer = SimpleNamespace(pad_token="pad", eos_token="eos")
+        model_class = Mock()
+        model_class.from_pretrained.side_effect = [
+            ModuleNotFoundError("No module named 'mamba_ssm'"),
+            SimpleNamespace(dtype=torch.float16),
+        ]
+
+        with (
+            patch(
+                "heretic.model.AutoTokenizer.from_pretrained", return_value=tokenizer
+            ),
+            patch("heretic.model.get_model_class", return_value=model_class),
+            patch("heretic.model.empty_cache") as empty_cache,
+        ):
+            with self.assertRaisesRegex(Exception, r"auto \[non-retryable\]"):
+                Model(cast(Settings, make_settings(["auto", "float16"])))
+
+        model_class.from_pretrained.assert_called_once()
+        empty_cache.assert_called_once()
+
+    def test_retries_after_retryable_error(self) -> None:
+        tokenizer = SimpleNamespace(pad_token="pad", eos_token="eos")
+        model_class = Mock()
+        loaded_model = SimpleNamespace(dtype=torch.float16)
+        model_class.from_pretrained.side_effect = [
+            RuntimeError("CUDA out of memory"),
+            loaded_model,
+        ]
+
+        with (
+            patch(
+                "heretic.model.AutoTokenizer.from_pretrained", return_value=tokenizer
+            ),
+            patch("heretic.model.get_model_class", return_value=model_class),
+            patch("heretic.model.empty_cache") as empty_cache,
+            patch.object(Model, "generate"),
+            patch.object(Model, "_apply_lora"),
+            patch.object(Model, "get_layers", return_value=[]),
+        ):
+            model = Model(cast(Settings, make_settings(["auto", "float16"])))
+
+        self.assertIs(model.model, loaded_model)
+        self.assertEqual(empty_cache.call_count, 1)
+        self.assertEqual(
+            [
+                call.kwargs["dtype"]
+                for call in model_class.from_pretrained.call_args_list
+            ],
+            ["auto", "float16"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refs #82, #147\n\nClassify explicit non-recoverable model-load failures such as unsupported architectures, missing dependencies, and invalid dtypes. These failures now clear the cache and stop futile dtype retries, while retryable runtime failures (including memory errors) continue through the configured fallback order. The final exception retains the dtype, classification, and formatted reason.\n\nTests: python -W error::SyntaxWarning -m unittest discover -s tests -p "test_*.py"; ruff check; ruff format --check; ty check.