### PR TITLE
fix: defer bitsandbytes import until use

### DIFF
--- a/src/heretic/model.py
+++ b/src/heretic/model.py
@@ -6,7 +6,6 @@ from contextlib import suppress
 from dataclasses import dataclass
 from typing import Any, Type, cast
 
-import bitsandbytes as bnb
 import torch
 import torch.linalg as LA
 import torch.nn.functional as F
@@ -542,6 +541,8 @@ class Model:
                         W = base_weight.to(torch.float32)
                     else:
                         # 4-bit quantization.
+                        import bitsandbytes as bnb
+
                         # This cast is always valid. Type inference fails here because the
                         # bnb.functional module is not found by ty for some reason.
                         W = cast(

--- a/tests/test_model_import.py
+++ b/tests/test_model_import.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2025-2026  Philipp Emanuel Weidmann <pew@worldwidemann.com> + contributors
+
+import subprocess
+import sys
+import textwrap
+import unittest
+
+
+class ModelImportTests(unittest.TestCase):
+    def test_model_import_does_not_require_bitsandbytes(self) -> None:
+        script = textwrap.dedent(
+            """
+            import builtins
+
+            original_import = builtins.__import__
+
+            def reject_bitsandbytes(name, *args, **kwargs):
+                if name == "bitsandbytes" or name.startswith("bitsandbytes."):
+                    raise AssertionError("bitsandbytes imported while loading heretic.model")
+                return original_import(name, *args, **kwargs)
+
+            builtins.__import__ = reject_bitsandbytes
+
+            import heretic.model
+            """
+        )
+
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- remove the unconditional module-level `bitsandbytes` import
- import `bitsandbytes` only when a quantized weight actually requires 4-bit dequantization
- add a subprocess regression test that rejects any `bitsandbytes` import while loading `heretic.model`

This prevents an unrelated bitsandbytes native-library traceback from being emitted at startup for non-BNB use while preserving the existing failure behavior when 4-bit dequantization is actually required.

Fixes #429.

## Verification

- `uv run --frozen python -m unittest discover -s tests -p "test_*.py"` — 5 passed
- `uv run --frozen ruff format --check .`
- `uv run --frozen ruff check --output-format=github --extend-select I .`
- `uv run --frozen ty check --output-format=github --error-on-warning .`
- `git diff --check`

AI assistance from TRAE was used for repository analysis, test drafting, and review. I reviewed the complete diff and ran the verification above.