### PR TITLE
feat: support specifying a dataset's specific config/subset

### DIFF
--- a/config.default.toml
+++ b/config.default.toml
@@ -137,6 +137,8 @@ system_prompt = "You are a helpful assistant."
 # or a path to a plain text file with one prompt per line (empty lines are ignored).
 # For text files, "column" is ignored and "split" is optional; when given, it selects
 # a subset of the lines using slice notation (e.g. "[:400]").
+# "config" specifies a dataset's specific config/subset name (e.g. "english", "hindi").
+# Leave unset for datasets with a single configuration.
 
 # Dataset of prompts that tend to not result in refusals (used for calculating residual directions).
 [good_prompts]

--- a/src/heretic/config.py
+++ b/src/heretic/config.py
@@ -49,17 +49,17 @@ class DatasetSpecification(BaseModel):
         description="Hugging Face dataset ID, or path to dataset on disk."
     )
 
+    commit: str | None = Field(
+        default=None,
+        description="Hugging Face commit hash of the dataset.",
+    )
+
     config: str | None = Field(
         default=None,
         description=(
             "Dataset config/subset name. Each config can have its own split. "
             "Used to load a specific config of a dataset that has multiple configurations."
         ),
-    )
-
-    commit: str | None = Field(
-        default=None,
-        description="Hugging Face commit hash of the dataset.",
     )
 
     split: str | None = Field(

--- a/src/heretic/config.py
+++ b/src/heretic/config.py
@@ -49,6 +49,14 @@ class DatasetSpecification(BaseModel):
         description="Hugging Face dataset ID, or path to dataset on disk."
     )
 
+    config: str | None = Field(
+        default=None,
+        description=(
+            "Dataset config/subset name. Each config can have its own split. "
+            "Used to load a specific config of a dataset that has multiple configurations."
+        ),
+    )
+
     commit: str | None = Field(
         default=None,
         description="Hugging Face commit hash of the dataset.",

--- a/src/heretic/utils.py
+++ b/src/heretic/utils.py
@@ -208,7 +208,7 @@ def load_prompts(
                     )
             dataset = load_dataset(
                 path,
-                config_name=specification.config,
+                specification.config,
                 revision=specification.commit,
                 split=split_str,
             )
@@ -226,7 +226,7 @@ def load_prompts(
             # Path should be a local directory.
             dataset = load_dataset(
                 path,
-                config_name=specification.config,
+                specification.config,
                 split=split_str,
                 # Don't require the number of examples (lines) per split to be pre-defined.
                 verification_mode=VerificationMode.NO_CHECKS,

--- a/src/heretic/utils.py
+++ b/src/heretic/utils.py
@@ -208,7 +208,7 @@ def load_prompts(
                     )
             dataset = load_dataset(
                 path,
-                specification.config,
+                name=specification.config,
                 revision=specification.commit,
                 split=split_str,
             )
@@ -226,7 +226,7 @@ def load_prompts(
             # Path should be a local directory.
             dataset = load_dataset(
                 path,
-                specification.config,
+                name=specification.config,
                 split=split_str,
                 # Don't require the number of examples (lines) per split to be pre-defined.
                 verification_mode=VerificationMode.NO_CHECKS,

--- a/src/heretic/utils.py
+++ b/src/heretic/utils.py
@@ -208,6 +208,7 @@ def load_prompts(
                     )
             dataset = load_dataset(
                 path,
+                config_name=specification.config,
                 revision=specification.commit,
                 split=split_str,
             )
@@ -225,6 +226,7 @@ def load_prompts(
             # Path should be a local directory.
             dataset = load_dataset(
                 path,
+                config_name=specification.config,
                 split=split_str,
                 # Don't require the number of examples (lines) per split to be pre-defined.
                 verification_mode=VerificationMode.NO_CHECKS,


### PR DESCRIPTION
# Support specifying a dataset's specific config/subset

Heretic currently only supports specifying the `split` and `column` of a specific dataset on huggingface. But `datasets` library or huggingface has a limit of only having **three** splits per `config` (e.g `train`, `test`, `validation`).

most datasets only have a single config `default`, which can only have three splits as explained. So for having multiple things in a single dataset, for example: *"Storing the same dataset in different languages"*.

And for this, we use a `config/subset` where each of these configs can have its own separate splits (three). This PR implements specifying  a `config/subset` for the `good_prompts` and `bad_prompts` for heretic. And I think the amount of `configs / subsets` we can have in a dataset, does not have an *unreasonable* limit.

## Why I need this feature?

Because I'm about to release the **new multilingual dataset** of harmful / harmless prompt pairs used by heretic, which would be the *translation* of the two original datasets [(1) `heretic-org/Semantic-Harmless`](https://huggingface.co/datasets/heretic-org/Semantic-Harmless) and [(2) `heretic-org/Semantic-Harmful`](https://huggingface.co/datasets/heretic-org/Semantic-Harmful) into different languages like **Hindi, Marathi, Bengali, Tamil, Russian, Italian, French**, and more in the future...


### I expect this dataset to be used for any research related to [Abliteration in a multilingual model. #65](https://github.com/p-e-w/heretic/issues/65) or "How refusal behavior differs across different languages" or any similar topics.