### PR TITLE
feat: model tensor integrity check

### DIFF
--- a/config.default.toml
+++ b/config.default.toml
@@ -130,6 +130,9 @@ study_checkpoint_dir = "checkpoints"
 # Maximum size for individual safetensors files generated when exporting a model.
 max_shard_size = "5GB"
 
+# Whether to check that this environment can save the model faithfully (throwaway save).
+preflight_check = true
+
 # System prompt to use when prompting the model.
 system_prompt = "You are a helpful assistant."
 

--- a/src/heretic/config.py
+++ b/src/heretic/config.py
@@ -490,6 +490,15 @@ class Settings(BaseSettings):
         description="Maximum size for individual safetensors files generated when exporting a model.",
     )
 
+    preflight_check: bool = Field(
+        default=True,
+        description=(
+            "Whether to check that this environment can save the model faithfully, "
+            "by writing a throwaway save before optimization."
+        ),
+        exclude=True,
+    )
+
     export_strategy: ExportStrategy | None = Field(
         default=None,
         description='How to export the model: "merge", "adapter", or unset to prompt the user.',

--- a/src/heretic/main.py
+++ b/src/heretic/main.py
@@ -81,6 +81,7 @@ from .reproduce import (
     load_reproduction_information,
 )
 from .system import empty_cache, get_accelerator_info
+from .tensor_check import check_tensors
 from .utils import (
     ask_if_unset,
     format_duration,
@@ -1067,6 +1068,7 @@ def run():
                                 model.tokenizer.save_pretrained(save_directory)
                                 if model.processor is not None:
                                     model.processor.save_pretrained(save_directory)
+                                check_tensors(model.source_shapes, save_directory)
                                 reset_trial_model()
 
                             print(f"Model saved to [bold]{save_directory}[/].")
@@ -1130,6 +1132,8 @@ def run():
                             )
                             if not repo_id:
                                 continue
+                            if "/" not in repo_id:
+                                repo_id = f"{user['name']}/{repo_id}"
 
                             visibility = ask_if_unset(
                                 None
@@ -1247,6 +1251,7 @@ def run():
                                         private=private,
                                         token=token,
                                     )
+                                check_tensors(model.source_shapes, repo_id, token=token)
                                 reset_trial_model()
 
                             if is_hf_path(settings.model):

--- a/src/heretic/main.py
+++ b/src/heretic/main.py
@@ -1221,6 +1221,7 @@ def run():
                             else:
                                 reproducibility_information = "none"
 
+                            differences = None
                             if strategy == ExportStrategy.ADAPTER:
                                 print("Uploading LoRA adapter...")
                                 model.model.push_to_hub(
@@ -1251,7 +1252,9 @@ def run():
                                         private=private,
                                         token=token,
                                     )
-                                check_tensors(model.source_shapes, repo_id, token=token)
+                                differences = check_tensors(
+                                    model.source_shapes, repo_id, token=token
+                                )
                                 reset_trial_model()
 
                             if is_hf_path(settings.model):
@@ -1304,6 +1307,7 @@ def run():
                                         include_system_information=(
                                             reproducibility_information == "full"
                                         ),
+                                        tensor_differences=differences,
                                     )
                                 finally:
                                     settings.export_strategy = current_export_strategy

--- a/src/heretic/main.py
+++ b/src/heretic/main.py
@@ -76,6 +76,7 @@ from .config import ExportStrategy, QuantizationMethod
 from .evaluator import Evaluator
 from .model import AbliterationParameters, Model, get_model_class
 from .reproduce import (
+    check_differences,
     check_environment,
     collect_reproducibles,
     load_reproduction_information,
@@ -1050,6 +1051,7 @@ def run():
                             if strategy is None:
                                 continue
 
+                            differences = None
                             if strategy == ExportStrategy.ADAPTER:
                                 print("Saving LoRA adapter...")
                                 model.model.save_pretrained(
@@ -1068,12 +1070,15 @@ def run():
                                 model.tokenizer.save_pretrained(save_directory)
                                 if model.processor is not None:
                                     model.processor.save_pretrained(save_directory)
-                                check_tensors(model.source_shapes, save_directory)
+                                differences = check_tensors(
+                                    model.source_shapes, save_directory
+                                )
                                 reset_trial_model()
 
                             print(f"Model saved to [bold]{save_directory}[/].")
 
                             if reproduction_mode:
+                                check_differences(differences, reproduction_information)
                                 print("Verifying hashes of weight files...")
 
                                 for (
@@ -1315,6 +1320,7 @@ def run():
                             print(f"Model uploaded to [bold]{repo_id}[/].")
 
                             if reproduction_mode:
+                                check_differences(differences, reproduction_information)
                                 print("Verifying hashes of weight files...")
 
                                 api = HfApi()

--- a/src/heretic/model.py
+++ b/src/heretic/model.py
@@ -63,7 +63,7 @@ class Model:
     # Set for multimodal models, None for text-only ones.
     processor: ProcessorMixin | None
     peft_config: LoraConfig
-    source_shapes: dict[str, tuple[int, ...]]
+    source_shapes: dict[str, list[int]]
     dtype: torch.dtype
 
     def __init__(self, settings: Settings):

--- a/src/heretic/model.py
+++ b/src/heretic/model.py
@@ -4,6 +4,7 @@
 import math
 from contextlib import suppress
 from dataclasses import dataclass
+from tempfile import TemporaryDirectory
 from typing import Any, Type, cast
 
 import bitsandbytes as bnb
@@ -31,8 +32,9 @@ from transformers.generation import (
     GenerateDecoderOnlyOutput,  # ty:ignore[possibly-missing-import]
 )
 
-from .config import QuantizationMethod, RowNormalization, Settings
+from .config import ExportStrategy, QuantizationMethod, RowNormalization, Settings
 from .system import empty_cache
+from .tensor_check import check_tensors, tensor_shapes
 from .utils import Prompt, batchify, format_exception, print
 
 
@@ -61,6 +63,7 @@ class Model:
     # Set for multimodal models, None for text-only ones.
     processor: ProcessorMixin | None
     peft_config: LoraConfig
+    source_shapes: dict[str, tuple[int, ...]]
     dtype: torch.dtype
 
     def __init__(self, settings: Settings):
@@ -167,6 +170,28 @@ class Model:
 
         if self.model is None:
             raise Exception("Failed to load model with all configured dtypes.")
+
+        # A PEFT adapter source has no model weights to compare a save against.
+        self.source_shapes = (
+            {}
+            if self.model._hf_peft_config_loaded
+            else tensor_shapes(settings.model, **self.revision_kwargs)
+        )
+
+        # A quantized model saves bitsandbytes tensors that the source checkpoint lacks.
+        if (
+            settings.preflight_check
+            and self.source_shapes
+            and settings.evaluate_model is None  # evaluation runs never save
+            and settings.quantization == QuantizationMethod.NONE
+            and settings.export_strategy != ExportStrategy.ADAPTER  # no merged save
+        ):
+            try:
+                with TemporaryDirectory(dir=".", prefix="heretic-preflight-") as path:
+                    self.model.save_pretrained(path)
+                    check_tensors(self.source_shapes, path)
+            except Exception as error:
+                print(f"* Preflight save failed: {error}", markup=False)
 
         self._apply_lora()
 

--- a/src/heretic/reproduce.py
+++ b/src/heretic/reproduce.py
@@ -389,3 +389,14 @@ def check_environment(
     else:
         # There are no mismatches at all, so there is nothing to confirm.
         return True
+
+
+def check_differences(
+    differences: dict[str, Any] | None, reproduction_information: dict[str, Any]
+) -> None:
+    recorded = reproduction_information.get("tensor_differences")
+    if differences is not None and recorded is not None:
+        if differences == recorded:
+            print("[green]Tensor differences match the original run[/]")
+        else:
+            print("[yellow]Tensor differences don't match the original run[/]")

--- a/src/heretic/tensor_check.py
+++ b/src/heretic/tensor_check.py
@@ -34,24 +34,26 @@ def tensor_shapes(
 
 def check_tensors(
     source: dict[str, tuple[int, ...]], location: str, token: str | None = None
-) -> None:
+) -> dict[str, list[tuple[int, ...] | None]] | None:
     if not source:
-        return
+        return None
     written = tensor_shapes(location, token=token)
     if not written:
-        return
+        return None
     names = sorted(set(source) | set(written))
-    differences = [
-        f"{name}: {source.get(name, 'absent')} -> {written.get(name, 'absent')}"
+    differences = {
+        name: [source.get(name), written.get(name)]
         for name in names
         if source.get(name) != written.get(name)
-    ]
-    if not differences:
+    }
+    if differences:
+        print(
+            f"[yellow]* Model differs from the source checkpoint at [bold]"
+            f"{len(differences)}[/] of {len(names)} names (source -> saved):[/]"
+        )
+        for name in list(differences)[:10]:
+            before, after = source.get(name, "absent"), written.get(name, "absent")
+            print(f"[yellow]    {escape(f'{name}: {before} -> {after}')}[/]")
+    else:
         print("* Model matches the source checkpoint")
-        return
-    print(
-        f"[yellow]* Model differs from the source checkpoint at [bold]"
-        f"{len(differences)}[/] of {len(names)} names (source -> saved):[/]"
-    )
-    for difference in differences[:10]:
-        print(f"[yellow]    {escape(difference)}[/]")
+    return differences

--- a/src/heretic/tensor_check.py
+++ b/src/heretic/tensor_check.py
@@ -11,7 +11,7 @@ from .utils import print
 
 def tensor_shapes(
     location: str, revision: str | None = None, token: str | None = None
-) -> dict[str, tuple[int, ...]]:
+) -> dict[str, list[int]]:
     try:
         if token is not None:
             metadata = huggingface_hub.get_safetensors_metadata(location, token=token)
@@ -26,15 +26,15 @@ def tensor_shapes(
         print(f"* Could not read {location}: {error}", markup=False)
         return {}
     return {
-        name: tuple(info.shape)
+        name: info.shape
         for file in metadata.files_metadata.values()
         for name, info in file.tensors.items()
     }
 
 
 def check_tensors(
-    source: dict[str, tuple[int, ...]], location: str, token: str | None = None
-) -> dict[str, list[tuple[int, ...] | None]] | None:
+    source: dict[str, list[int]], location: str, token: str | None = None
+) -> dict[str, list[list[int] | None]] | None:
     if not source:
         return None
     written = tensor_shapes(location, token=token)

--- a/src/heretic/tensor_check.py
+++ b/src/heretic/tensor_check.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2025-2026  Philipp Emanuel Weidmann <pew@worldwidemann.com> + contributors
+
+from pathlib import Path
+
+import huggingface_hub
+from rich.markup import escape
+
+from .utils import print
+
+
+def tensor_shapes(
+    location: str, revision: str | None = None, token: str | None = None
+) -> dict[str, tuple[int, ...]]:
+    try:
+        if token is not None:
+            metadata = huggingface_hub.get_safetensors_metadata(location, token=token)
+        else:
+            snapshot = location
+            if not Path(location).is_dir():
+                snapshot = huggingface_hub.snapshot_download(
+                    location, revision=revision, local_files_only=True
+                )
+            metadata = huggingface_hub.get_local_safetensors_metadata(snapshot)
+    except Exception as error:
+        print(f"* Could not read {location}: {error}", markup=False)
+        return {}
+    return {
+        name: tuple(info.shape)
+        for file in metadata.files_metadata.values()
+        for name, info in file.tensors.items()
+    }
+
+
+def check_tensors(
+    source: dict[str, tuple[int, ...]], location: str, token: str | None = None
+) -> None:
+    if not source:
+        return
+    written = tensor_shapes(location, token=token)
+    if not written:
+        return
+    names = sorted(set(source) | set(written))
+    differences = [
+        f"{name}: {source.get(name, 'absent')} -> {written.get(name, 'absent')}"
+        for name in names
+        if source.get(name) != written.get(name)
+    ]
+    if not differences:
+        print("* Model matches the source checkpoint")
+        return
+    print(
+        f"[yellow]* Model differs from the source checkpoint at [bold]"
+        f"{len(differences)}[/] of {len(names)} names (source -> saved):[/]"
+    )
+    for difference in differences[:10]:
+        print(f"[yellow]    {escape(difference)}[/]")

--- a/src/heretic/utils.py
+++ b/src/heretic/utils.py
@@ -562,6 +562,7 @@ def generate_reproduce_json(
     timestamp: str,
     uploaded_model_hashes: dict[str, str],
     include_system_information: bool,
+    tensor_differences: dict[str, Any] | None,
 ) -> str:
     """Generates the contents of a reproduce.json file for the reproduce/ folder."""
 
@@ -588,6 +589,7 @@ def generate_reproduce_json(
         },
         "scores": trial.user_attrs["scores"],
         "hashes": uploaded_model_hashes,
+        "tensor_differences": tensor_differences,
     }
 
     if include_system_information:
@@ -637,6 +639,7 @@ def create_reproduce_folder(
     trial: Trial | FrozenTrial,
     uploaded_model_hashes: dict[str, str],
     include_system_information: bool,
+    tensor_differences: dict[str, Any] | None,
 ):
     reproduce_dir = path / "reproduce"
     reproduce_dir.mkdir(parents=True, exist_ok=True)
@@ -674,6 +677,7 @@ def create_reproduce_folder(
             timestamp=timestamp,
             uploaded_model_hashes=uploaded_model_hashes,
             include_system_information=include_system_information,
+            tensor_differences=tensor_differences,
         ),
         encoding="utf-8",
     )
@@ -701,6 +705,7 @@ def upload_reproduce_folder(
     checkpoint_path: str | Path,
     trial: Trial | FrozenTrial,
     include_system_information: bool,
+    tensor_differences: dict[str, Any] | None,
 ):
     api = huggingface_hub.HfApi()
     info = api.model_info(repo_id=repo_id, files_metadata=True, token=token)
@@ -729,6 +734,7 @@ def upload_reproduce_folder(
             trial=trial,
             uploaded_model_hashes=uploaded_model_hashes,
             include_system_information=include_system_information,
+            tensor_differences=tensor_differences,
         )
 
         reproduce_dir = tmp_path / "reproduce"


### PR DESCRIPTION
Supersedes https://github.com/p-e-w/heretic/pull/420.

Core differences in functionality:

1. The forced garbage collection after loading is gone. It only existed to collect leaked progress bars from the tqdm patch, which master has disabled.
2. The upload path no longer writes anything locally. The check reads the published safetensors headers back from the Hub after push_to_hub returns.
3. The differences the tensor check finds are recorded in reproduce.json, and reproduction mode verifies them alongside the hashes.

I have taken upon myself the liberty to rule on the latter two. On the second I did not yet have an explicit ruling, so I went with the option that seemed reasonable to me. The third I have decided to add because it is evident that differences in the way Transformers saves weights can be rather fatal to reproduction attempts. Recording them therefore is important, and it is useful to have this data in the HF repo of the model regardless, as it would help people understand the differences between the input and the output model better. This integration with Heretic's reproducibility suite can be rolled back (the two commits that sit on top of the first one are responsible for it), bringing the PR back to 100 lines of code.